### PR TITLE
Fixed an theme issue

### DIFF
--- a/core/paths.php
+++ b/core/paths.php
@@ -21,5 +21,5 @@
 	if (substr($urlpath, 0, 1) != '/') { $urlpath = '/' . $urlpath; }
 
 //	Theme path
-	$themepath = $urlpath . 'themes/' . $theme . '/';
+	$themepath = $urlpath . 'themes/' . (isset($theme) ? $theme : 'default') . '/';
 ?>


### PR DESCRIPTION
Fixed a theme issue where Anchor wouldn't see any themes, regardless of the name of the folder, and wouldn't load the default. Replaced line 24 on paths.php so it would default to the 'default' theme correctly.
