### PR TITLE
Initializing $errors in stage4 of installation

### DIFF
--- a/install/models/installer.php
+++ b/install/models/installer.php
@@ -220,6 +220,8 @@ class Installer {
 	}
 
 	public static function stage4() {
+		$errors = array();
+
 		$post = post(array('username', 'email', 'password', 'confirm_password'));
 
 		if(empty($post['username'])) {


### PR DESCRIPTION
When I went to install this CMS it kept throwing errors on stage 4. This patch fixes that error by initializing $errors.
