### PR TITLE
menu_rewind(): use when multiple menus needed

### DIFF
--- a/system/functions/menus.php
+++ b/system/functions/menus.php
@@ -11,6 +11,16 @@ function has_menu_items() {
 	return $total;
 }
 
+function menu_rewind() {
+	if(($pages = IoC::resolve('menu')) === false) {
+		$params['status'] = 'published';
+		$pages = Pages::list_all($params);
+		IoC::instance('menu', $pages, true);
+	}
+	
+	$pages->rewind();
+}
+
 function menu_items($params = array()) {
 	if(!has_menu_items()) {
 		return false;
@@ -29,7 +39,7 @@ function menu_items($params = array()) {
 		// move to next
 		$pages->next();
 	}
-
+	
 	return $result;
 }
 


### PR DESCRIPTION
Hi,

For responsive design reasons I needed two menu markups one after each other. Since menu_items() doesn't rewind by itself, I added a new method: menu_rewind(), which just calls your $pages->rewind(). Nothing special :]

Thanks for the project, I installed it an hour ago and I already like it a lot.

Vaclav
