### PR TITLE
Re-enabled browser autocomplete

### DIFF
--- a/install/views/stage1.php
+++ b/install/views/stage1.php
@@ -23,7 +23,7 @@
 		new blog set up in no time.</p>
 	</article>
 
-	<form method="post" action="index.php" autocomplete="off">
+	<form method="post" action="index.php>
 		<fieldset>
 			<p>
 				<label for="lang">


### PR DESCRIPTION
Disabling autocomplete is a big no-no for users, especially on fields which may be repeated on multiple installations, such as the database login details. I'd propose it's re-enabled in other pages as well, like in the login details page
