### PR TITLE
Update system/library/error.php

### DIFF
--- a/system/library/error.php
+++ b/system/library/error.php
@@ -46,10 +46,7 @@ class Error {
 			$contexts = static::context($file, $e->getLine());
 
 			require PATH . 'system/admin/theme/error_php.php';
-		} else {
-			require PATH . 'system/admin/theme/error_500.php';
 		}
-
 		exit(1);
 	}
 


### PR DESCRIPTION
Removed this because in certain environments simple notices caused unofficial fatal 500s. For instance, on Hostgator, if you run the default installation, it will tell you register_globals is deprecated in file "Unknown" on "Line 0". This should not cause a 500 error under any circumstances. Another such example was claiming $_SESSION was an undefined variable in bootstrap when the $globals array is being built - this caused another fatal. (See separate PR for that)
