### PR TITLE
Redirect users without mod_rewrite to base directory

### DIFF
--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -11,5 +11,5 @@
 </IfModule>
 
 <IfModule !mod_rewrite.c>
-	ErrorDocument 404 index.php
+	ErrorDocument 404 {base}
 </IfModule>


### PR DESCRIPTION
First pull request, please excuse any mistakes.

Currently, if a user does not have mod_rewrite installed or enabled, it simply prints 'index.php' 

This should fix that for new installs, haven't tested with upgrades.
