### PR TITLE
When logged in viewing login / amnesia showed the login form + admin hea...

### DIFF
--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -9,6 +9,8 @@ Route::get('admin', function() {
 	Log in
 */
 Route::get('admin/login', function() {
+	if(Auth::user()) return Response::redirect('admin/posts');
+
 	$vars['messages'] = Notify::read();
 	$vars['token'] = Csrf::token();
 
@@ -46,6 +48,8 @@ Route::get('admin/logout', function() {
 	Amnesia
 */
 Route::get('admin/amnesia', function() {
+	if(Auth::user()) return Response::redirect('admin/posts');
+
 	$vars['messages'] = Notify::read();
 	$vars['token'] = Csrf::token();
 


### PR DESCRIPTION
While playing around I noticed that for whatever reason I might sometimes appear back at the login page while logged in. This displayed both the form and the admin so instead I added a check to redirect to admin/posts if the user is logged in already.

Not sure if its just adding unnecessary bloat though. I can't imagine too many times this would occur but it could if they linked to the login page rather than the admin page and relied on the router to do its work.
