### PR TITLE
Fixing 404 on Admin Page

### DIFF
--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -9,7 +9,7 @@ Options -indexes
 	RewriteCond %{REQUEST_FILENAME} !-d
 
 	# Rewrite all other URLs to index.php/URL
-	RewriteRule ^(.*)$ {{index}} [L]
+	RewriteRule ^(.*)$ {{index}}/$1 [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>


### PR DESCRIPTION
/$1 got deleted from the RewriteRule...so I put it back.

Deets:
I got a 404 at http://example.com/admin/login/. When I added index.php to the url, http://example.com/index.php/admin/login/, it worked perfectly. Went through and compared the master branch's htaccess.distro.php with the one in the dev branch and found the problem.

Not sure why it was deleted in the first place?
