### PR TITLE
Amended login link on install complete screen

### DIFF
--- a/install/views/complete.php
+++ b/install/views/complete.php
@@ -12,7 +12,7 @@
 	<?php endif; ?>
 
 	<section class="options">
-		<a href="<?php echo $site_uri; ?>index.php/admin" class="button">Visit your admin panel</a>
+		<a href="<?php echo $site_uri; ?>/index.php/admin/login" class="button">Visit your admin panel</a>
 		<a href="<?php echo $site_uri; ?>" class="right">Visit your new site</a>
 	</section>
 </section>


### PR DESCRIPTION
Missing a / plus added /login to the end, just to be sure it takes them to the login page for the first time.
