### PR TITLE
Give relevance to REQUEST_URI over PATH_INFO

### DIFF
--- a/system/uri.php
+++ b/system/uri.php
@@ -86,7 +86,7 @@ class Uri {
 	 * @return string
 	 */
 	public static function detect() {
-		$try = array('PATH_INFO', 'ORIG_PATH_INFO', 'REQUEST_URI');
+		$try = array('REQUEST_URI', 'PATH_INFO', 'ORIG_PATH_INFO');
 
 		foreach($try as $method) {
 			if( ! array_key_exists($method, $_SERVER)) continue;


### PR DESCRIPTION
I recenlty installed AnchorCMS on my localhost `XAMPP Ubuntu 12.04.2` and after the installation every route goes to the homepage, after checking around I've seen that (in the nano framework) we give prefference to `$_SERVER['PATH_INFO']` over `$_SERVER['REQUEST_URI']`, I changed to the actual one of the commit and now it seems to work fine.

Sorry my bad english :)
