### PR TITLE
Fixed htaccess syntax

### DIFF
--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -9,7 +9,7 @@ Options -indexes
 	RewriteCond %{REQUEST_FILENAME} !-d
 
 	# Rewrite all other URLs to index.php/URL
-	RewriteRule ^ {{index}} [L]
+	RewriteRule ^(.*)$ {{index}} [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>


### PR DESCRIPTION
Fixed `.htaccess` syntax ceated in AnchorCMS installer
