### PR TITLE
Removed changes wrongly committed with issue #316

### DIFF
--- a/themes/default/article.php
+++ b/themes/default/article.php
@@ -3,8 +3,6 @@
 		<section class="content wrap" id="article-<?php echo article_id(); ?>">
 			<h1><?php echo article_title(); ?></h1>
 
-			<img src="<?php echo article_custom_field('Test'); ?>" alt="">
-
 			<article>
 				<?php echo article_markdown(); ?>
 			</article>


### PR DESCRIPTION
An article_custom_field was accidentally committed and merged into article.php of the default theme. This removes it
