### PR TITLE
Two minor typos in en_GB/comments.php

### DIFF
--- a/anchor/language/en_GB/comments.php
+++ b/anchor/language/en_GB/comments.php
@@ -4,8 +4,8 @@ return array(
 
 	'comments' => 'Comments',
 	'nocomments_desc' => 'No comments yet.',
-	'editing_comment' => 'Editing Comment',
-	'view_comment' => 'View Comment',
+	'editing_comment' => 'Editing comment',
+	'view_comment' => 'View comment',
 
 	// form fields
 	'name' => 'Name',


### PR DESCRIPTION
Uncapitalized to instances of "comment" for consistency.
