### PR TITLE
Remove slug and title limits from pages.php and posts.php

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -89,10 +89,10 @@ Route::collection(array('before' => 'auth'), function() {
 		});
 
 		$validator->check('title')
-			->is_max(3, __('pages.title_missing'));
+			->is_max(1, __('pages.title_missing'));
 
 		$validator->check('slug')
-			->is_max(3, __('pages.slug_missing'))
+			->is_max(1, __('pages.slug_missing'))
 			->is_duplicate(__('pages.slug_duplicate'))
 			->not_regex('#^[0-9_-]+$#', __('pages.slug_invalid'));
 

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -97,10 +97,10 @@ Route::collection(array('before' => 'auth'), function() {
 		});
 
 		$validator->check('title')
-			->is_max(3, __('posts.title_missing'));
+			->is_max(1, __('posts.title_missing'));
 
 		$validator->check('slug')
-			->is_max(3, __('posts.slug_missing'))
+			->is_max(1, __('posts.slug_missing'))
 			->is_duplicate(__('posts.slug_duplicate'))
 			->not_regex('#^[0-9_-]+$#', __('posts.slug_invalid'));
 


### PR DESCRIPTION
User can create short slugs and titles.
