### PR TITLE
Stops article_next_url() and article_previous_url() functions from including draft articles.

### DIFF
--- a/anchor/functions/articles.php
+++ b/anchor/functions/articles.php
@@ -17,7 +17,8 @@ function article_slug() {
 
 function article_previous_url() {
 	$page = Registry::get('posts_page');
-	$query = Post::where('created', '<', Registry::prop('article', 'created'));
+	$query = Post::where('created', '<', Registry::prop('article', 'created'))
+				->where('status', '!=', 'draft');
 
 	if($query->count()) {
 		$article = $query->sort('created', 'desc')->fetch();
@@ -29,7 +30,8 @@ function article_previous_url() {
 
 function article_next_url() {
 	$page = Registry::get('posts_page');
-	$query = Post::where('created', '>', Registry::prop('article', 'created'));
+	$query = Post::where('created', '>', Registry::prop('article', 'created'))
+				->where('status', '!=', 'draft');
 
 	if($query->count()) {
 		$article = $query->sort('created', 'asc')->fetch();


### PR DESCRIPTION
Will skip drafts, and only point to published or archived articles.
