### PR TITLE
Fix for #375 (Firefox select box rendering)

### DIFF
--- a/anchor/views/assets/css/forms.css
+++ b/anchor/views/assets/css/forms.css
@@ -79,9 +79,9 @@ select {
 	display: block;
 	float: left;
 	height: 39px;
-	padding-left: 20px;
+	padding: 9px 0 8px 20px;
 
-	font: 15px/39px "Helvetica Neue", sans-serif;
+	font: 15px/22px "Helvetica Neue", sans-serif;
 
 	border: none;
 	border-radius: 0 5px 5px 0;

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -48,7 +48,7 @@
 				<label for="description"><?php echo __('posts.description'); ?>:</label>
 				<?php echo Form::textarea('description', Input::previous('description', $article->description)); ?>
 				<em><?php echo __('posts.description_explain'); ?></em>
-			</p
+			</p>
 			<p>
 				<label for="status"><?php echo __('posts.status'); ?>:</label>
 				<?php echo Form::select('status', $statuses, Input::previous('status', $article->status)); ?>


### PR DESCRIPTION
Adjusted select box CSS to render better in Firefox. Fixed a broken <p> tag in post edit view that caused weird spacing in Safari.

I don't know if I should have done this in the /dev branch but I couldn't get that branch running properly locally without database errors.
