### PR TITLE
issue #400 comment time conversion to local timezone

### DIFF
--- a/anchor/functions/comments.php
+++ b/anchor/functions/comments.php
@@ -52,7 +52,7 @@ function comment_id() {
 
 function comment_time() {
 	if($time = Registry::prop('comment', 'date')) {
-		return Date::format($time);
+		return Date::format($time,'U');
 	}
 }
 


### PR DESCRIPTION
Fixed problem where comment times where not being translated from GMT to local
timezone.

Before:

```
function comment_time() {
  if($time = Registry::prop('comment', 'date')) {
    return strtotime($time);
  }
}
```

After:

```
function comment_time() {
  if($time = Registry::prop('comment', 'date')) {
    return Date::format($time,'U');
  }
}
```
