### PR TITLE
Fix drag & drop urls

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -163,7 +163,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		$uploader = new Uploader(PATH . 'content', array('png', 'jpg', 'bmp', 'gif'));
 		$filepath = $uploader->upload($_FILES['file']);
 
-		$uri = Config::app('url', '/') . 'content/' . basename($filepath);
+		$uri = Config::app('url', '/') . '/content/' . basename($filepath);
 		$output = array('uri' => $uri);
 
 		return Response::json($output);

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -170,7 +170,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		$uploader = new Uploader(PATH . 'content', array('png', 'jpg', 'bmp', 'gif'));
 		$filepath = $uploader->upload($_FILES['file']);
 
-		$uri = Config::app('url', '/') . 'content/' . basename($filepath);
+		$uri = Config::app('url', '/') . '/content/' . basename($filepath);
 		$output = array('uri' => $uri);
 
 		return Response::json($output);


### PR DESCRIPTION
This fixes drag and drop urls missing a slash before content, as in #446. I'm not sure if this is the proper way to resolve this, but it seems to work.
