### PR TITLE
fix config.php for Windows that fucks up

### DIFF
--- a/install/libraries/installer/config.php
+++ b/install/libraries/installer/config.php
@@ -24,7 +24,7 @@ class Config {
 
 	private function app() {
 		$distro = Braces::compile(APP . 'storage/application.distro.php', array(
-			'url' => $this->session['metadata']['site_path'],
+			'url' => str_replace('\\','/',$this->session['metadata']['site_path']),
 			'index' => ($this->support->has_mod_rewrite() ? '' : 'index.php'),
 			'key' => noise(),
 			'language' => $this->session['i18n']['language'],


### PR DESCRIPTION
when you install AnchorCMS on Windows with the url on '/', Windows casts a dark spell on the anchor transforming the / to \ and the chain breaks and anchor is doomed to be on the sea bottom forever. but this should protect the chain for breaking. 

changing '\' to '/' or changing '\' to '\\' is debatable
