### PR TITLE
return an "empty" json object string by default

### DIFF
--- a/anchor/models/type.php
+++ b/anchor/models/type.php
@@ -19,7 +19,9 @@ class Type {
 
 	public function delete() {}
 
-	public static function attributes($input) {}
+	public static function attributes($input) {
+      return "{}";
+  }
 
 	public function __get($key) {
 		return $this->field->{$key};


### PR DESCRIPTION
avoids errors like #430

Pull Request brought to you from http://24pullrequests.com/users/Flyingmana
