### PR TITLE
Update category.php

### DIFF
--- a/anchor/models/category.php
+++ b/anchor/models/category.php
@@ -14,8 +14,9 @@ class Category extends Base {
 		return $items;
 	}
 
-	public static function slug($slug) {
-		return static::where('slug', 'like', $slug)->fetch();
+	
+	public static function slug($slug, $comparison = 'like') {
+		return static::where('slug', $comparison, $slug)->fetch();
 	}
 
 	public static function paginate($page = 1, $perpage = 10) {


### PR DESCRIPTION
I think it's supposed slug() to return a single record
so why not use '=' instead of 'like'? I had some troubles
working with it because it didn't returned the expected category.
To keep backward compatibility, I added a $comparison parameter:
this way, I managed to make it work for me with slug($slug, '=')
