### PR TITLE
Broken Selected Menu in Comments Page

### DIFF
--- a/anchor/views/comments/index.php
+++ b/anchor/views/comments/index.php
@@ -10,7 +10,7 @@
 	<nav class="sidebar statuses">
 		<?php foreach($statuses as $data): extract($data); ?>
 		<?php echo Html::link('admin/comments/' . $url, '<span class="icon"></span> ' . __($lang), array(
-			'class' => $class . (isset($status) and $status == $url ? ' active' : '')
+			'class' => $class . (isset($status) && $status == $url ? ' active' : '')
 		)); ?>
 		<?php endforeach; ?>
 	</nav>


### PR DESCRIPTION
The selected menu not working with `and`:

![2014-01-14_102034](https://f.cloud.github.com/assets/1669261/1907421/b6373dac-7ccb-11e3-8b85-cf232ea76789.png)
