### PR TITLE
Margin on ".top nav a" removed

### DIFF
--- a/anchor/views/assets/css/admin.css
+++ b/anchor/views/assets/css/admin.css
@@ -84,7 +84,6 @@ fieldset, a, img {
 	}
 
 	.top nav a {
-		margin-right: 15px;
 		color: #7b8eaa;
 	}
 


### PR DESCRIPTION
The margin breaks the layout in Spanish and probably other languages: some words are longer and the button list turns into two lines. Removing this margin doesn't change the appearance dramatically and allows translations to look fine out of the box.
