### PR TITLE
issue #586 fixed the bug with incorrect timezones

### DIFF
--- a/install/run.php
+++ b/install/run.php
@@ -38,11 +38,10 @@ if($route = Arr::get($_GET, 'route', '/')) {
 	Helper functions
 */
 function timezones() {
-	$list = DateTimeZone::listAbbreviations();
-	$idents = DateTimeZone::listIdentifiers();
+	$list = DateTimeZone::listIdentifiers();
 
 	$data = array();
-    foreach($idents as $id => $zone){
+    foreach($list as $id => $zone){
         $now = new DateTime(null, new DateTimeZone($zone));
         $offset = $now->getOffset();
         $offset_round = round(abs($offset / 3600), 2);


### PR DESCRIPTION
The Timezone dropdown before (listing different timezones multiple times):
![screenshot](https://cloud.githubusercontent.com/assets/497645/2623052/40e74f78-bcd7-11e3-9ce0-6518f154ca81.png)
The Timezone dropdown with the patch (listing each timezone only once, and offsets with time fraction not rounded up):
![screen2](https://cloud.githubusercontent.com/assets/497645/2623058/714e6692-bcd7-11e3-87aa-6bcade115ae9.png)
