### PR TITLE
Issue #602 solution

### DIFF
--- a/anchor/models/post.php
+++ b/anchor/models/post.php
@@ -15,6 +15,7 @@ class Post extends Base {
 	private static function get($row, $val) {
 		return static::left_join(Base::table('users'), Base::table('users.id'), '=', Base::table('posts.author'))
 			->where(Base::table('posts.'.$row), '=', $val)
+			->where(Base::table('posts.status'), '!=', 'draft')
 			->fetch(array(Base::table('posts.*'),
 				Base::table('users.id as author_id'),
 				Base::table('users.bio as author_bio'),


### PR DESCRIPTION
Make posts targeted as 'draft' inaccessible from the front website, even if you know the post's slug
