### PR TITLE
[0.9-dev] Fix XSS issues with current_url()

### DIFF
--- a/anchor/functions/helpers.php
+++ b/anchor/functions/helpers.php
@@ -31,7 +31,12 @@ function asset_url($extra = '') {
 	return asset('anchor/views/assets/' . ltrim($extra, '/'));
 }
 
+
 function current_url() {
+	return htmlentities(raw_current_url());
+}
+
+function raw_current_url() {
 	return Uri::current();
 }
 


### PR DESCRIPTION
The `current_url()` helper now sanitizes output by default using `htmlentities()`.

There is now a `raw_current_url()` that will give you unfiltered output.

![screen shot 2014-05-11 at 1 31 21 pm](https://cloud.githubusercontent.com/assets/740289/2939028/39c3eaea-d932-11e3-94dd-8bdec2d2c0a3.png)

See #574.
