### PR TITLE
Bug fixes, and desired features.

### DIFF
--- a/anchor/config/.htaccess
+++ b/anchor/config/.htaccess
@@ -1,0 +1,1 @@
+deny from all

--- a/install/routes.php
+++ b/install/routes.php
@@ -101,7 +101,7 @@ Route::post('database', array('before' => 'check', 'main' => function() {
 			'prefix' => $database['prefix']
 		));
 	}
-	catch(PDOException $e) {
+	catch(ErrorException $e) {
 		Input::flash();
 
 		Notify::error($e->getMessage());

--- a/install/routes.php
+++ b/install/routes.php
@@ -112,6 +112,15 @@ Route::post('database', array('before' => 'check', 'main' => function() {
 
 	// test connection
 	try {
+		
+		// It is technically valid for a user to leave an empty port
+		// Thus, to fix db.php write issues, we need to replace an empty
+		// string with quotations.
+
+		if(!$database['port']){
+			$database['port'] = "''";
+		} 
+		
 		$connection = DB::factory(array(
 			'driver' => 'mysql',
 			'database' => $database['name'],

--- a/install/views/assets/css/install.css
+++ b/install/views/assets/css/install.css
@@ -321,3 +321,10 @@ form .btn {
 form .quiet {
 	margin-right: 25px;
 }
+
+#dbCreate {
+	position:relative;
+	top:10px;
+	height: 17px;
+	width: 17px;
+}

--- a/install/views/database.php
+++ b/install/views/database.php
@@ -66,6 +66,13 @@
 
 				<i>Change if <b>utf8_general_ci</b> doesn’t work.</i>
 			</p>
+
+			<p>
+				<label for="dbCreate">Create Database</label>
+				<input id="dbCreate" name="dbCreate" type="checkbox" value="1" checked>
+
+				<i>If it doesn't already exist.</i>
+			</p>
 		</fieldset>
 
 		<section class="options">


### PR DESCRIPTION
mysql.php throws a diferent err than the "PDOException" it is trying to catch in routes. This leads to an ugly error page when a user tries to install to a database that doesn't exist. This patch catches the error, giving a prettier error page. Also adds the ability for the user to yay-or-nay the creation of a database if one doesn't already exist. Reference https://github.com/anchorcms/anchor-cms/issues/638