### PR TITLE
Made username length validation consistent

### DIFF
--- a/anchor/routes/users.php
+++ b/anchor/routes/users.php
@@ -54,7 +54,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		});
 
 		$validator->check('username')
-			->is_max(2, __('users.username_missing', 2));
+			->is_max(3, __('users.username_missing', 2));
 
 		$validator->check('email')
 			->is_email(__('users.email_missing'));
@@ -112,7 +112,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		$validator = new Validator($input);
 
 		$validator->check('username')
-			->is_max(2, __('users.username_missing', 2));
+			->is_max(3, __('users.username_missing', 2));
 
 		$validator->check('email')
 			->is_email(__('users.email_missing'));

--- a/install/routes.php
+++ b/install/routes.php
@@ -184,7 +184,7 @@ Route::post('account', array('before' => 'check', 'main' => function() {
 	$validator = new Validator($account);
 
 	$validator->check('username')
-		->is_max(4, 'Please enter a username');
+		->is_max(3, 'Please enter a username');
 
 	$validator->check('email')
 		->is_email('Please enter a valid email address');


### PR DESCRIPTION
As discussed in issue #668, the username length validations are now 3 characters across the entire application. I believe this is a sensible compromise between security and customisation, and makes validation consistent.
