### PR TITLE
Removed "csrf" from Route::collection

### DIFF
--- a/anchor/routes/menu.php
+++ b/anchor/routes/menu.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::collection(array('before' => 'auth,csrf'), function() {
+Route::collection(array('before' => 'auth'), function() {
 
 	/*
 		List Menu Items


### PR DESCRIPTION
That "csrf" prevents the menu from staying updated once the menu is changed.  Once it's taken out the menu behaves as normal.
