### PR TITLE
Removed "csrf" from Route::collection

### DIFF
--- a/anchor/routes/metadata.php
+++ b/anchor/routes/metadata.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::collection(array('before' => 'auth,csrf'), function() {
+Route::collection(array('before' => 'auth'), function() {
 
 	/*
 		List Metadata


### PR DESCRIPTION
That "csrf" prevents the metadata from staying updated once the metadata is changed.  Once it's taken out the metadata page behaves as normal.
