### PR TITLE
Fix AnchorCMS logo link on login page.

### DIFF
--- a/anchor/views/partials/header.php
+++ b/anchor/views/partials/header.php
@@ -48,7 +48,7 @@
 
 				<?php else: ?>
 				<aside class="logo">
-					<a href="<?php echo Uri::to('admin/users/login'); ?>">Anchor CMS</a>
+					<a href="<?php echo Uri::to('admin/login'); ?>">Anchor CMS</a>
 				</aside>
 				<?php endif; ?>
 			</div>


### PR DESCRIPTION
Logo link was redirecting to "/admin/users/login". Should to be "/admin/login".
