### PR TITLE
Update login.php considering security problems

### DIFF
--- a/anchor/views/users/login.php
+++ b/anchor/views/users/login.php
@@ -21,7 +21,8 @@
 			<p><label for="pass"><?php echo __('users.password'); ?>:</label>
 			<?php echo Form::password('pass', array(
 				'id' => 'pass',
-				'placeholder' => __('users.password')
+				'placeholder' => __('users.password'),
+				'autocomplete' => 'off'
 			)); ?></p>
 
 			<p class="buttons"><a href="<?php echo Uri::to('admin/amnesia'); ?>"><?php echo __('users.forgotten_password'); ?></a>


### PR DESCRIPTION
I've set the autocomplete attribute to off, considering security issues. This could help to prevent sensitive data from being cached on client side. Caching of form fields is present in most browsers.
