### PR TITLE
Removed faulty 'exit' in german translation.

### DIFF
--- a/anchor/language/de_DE/comments.php
+++ b/anchor/language/de_DE/comments.php
@@ -1,5 +1,4 @@
-
-exit<?php
+<?php
 
 return array(
 


### PR DESCRIPTION
In the german translation there were an faulty 'exit' in front of the
PHP tag. This resulted in some text displayed with an 'exit' in front of
it.
