### PR TITLE
Fix image type selection not show hidden input

### DIFF
--- a/anchor/views/assets/js/custom-fields.js
+++ b/anchor/views/assets/js/custom-fields.js
@@ -4,7 +4,7 @@
  * Show/hide fields depending on type
  */
 $(function() {
-	var select = $('#field'), attrs = $('.hide');
+	var select = $('#label-field'), attrs = $('.hide');
 
 	var update = function() {
 		var value = select.val();


### PR DESCRIPTION
Currently in `0.9-dev`, when Field type image selection not showing hidden input like **File types**, **Image max width** and **Image max height**.
