### PR TITLE
make field types a static in Extend

### DIFF
--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -11,6 +11,13 @@ class Extend extends Base {
 		'user' => 'user'
 	);
 
+	public static $field_types = array(
+		'text' => 'text',
+		'html' => 'html',
+		'image' => 'image',
+		'file' => 'file'
+	);
+
 	public static function field($type, $key, $id = -1) {
 		$field = Query::table(static::table())
 			->where('type', '=', $type)

--- a/anchor/routes/fields.php
+++ b/anchor/routes/fields.php
@@ -23,12 +23,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		$vars['token'] = Csrf::token();
 		$vars['types'] = Extend::$types;
 
-		$vars['fields'] = array(
-			'text' => 'text',
-			'html' => 'html',
-			'image' => 'image',
-			'file' => 'file'
-		);
+		$vars['fields'] = Extend::$field_types;
 
 		$vars['pagetypes'] = Query::table(Base::table('pagetypes'))->sort('key')->get();
 
@@ -103,12 +98,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 		$vars['messages'] = Notify::read();
 		$vars['token'] = Csrf::token();
 		$vars['types'] = Extend::$types;
-		$vars['fields'] = array(
-			'text' => 'text',
-			'html' => 'html',
-			'image' => 'image',
-			'file' => 'file'
-		);
+		$vars['fields'] = Extend::$field_types;
 
 		$extend = Extend::find($id);
 

--- a/anchor/views/extend/fields/add.php
+++ b/anchor/views/extend/fields/add.php
@@ -32,7 +32,7 @@
 			<p>
 				<label for="field"><?php echo __('extend.field'); ?>:</label>
 				<select id="label-field" name="field">
-					<?php foreach(array('text', 'html', 'image', 'file') as $type): ?>
+					<?php foreach($fields as $type): ?>
 					<?php $selected = (Input::previous('field') == $type) ? ' selected' : ''; ?>
 					<option<?php echo $selected; ?>><?php echo $type; ?></option>
 					<?php endforeach; ?>

--- a/anchor/views/extend/fields/edit.php
+++ b/anchor/views/extend/fields/edit.php
@@ -32,7 +32,7 @@
 			<p>
 				<label for="field"><?php echo __('extend.field'); ?>:</label>
 				<select id="label-field" name="field">
-					<?php foreach(array('text', 'html', 'image', 'file') as $type): ?>
+					<?php foreach($fields as $type): ?>
 					<?php $selected = (Input::previous('field', $field->field) == $type) ? ' selected' : ''; ?>
 					<option<?php echo $selected; ?>><?php echo $type; ?></option>
 					<?php endforeach; ?>


### PR DESCRIPTION
This just adds a new static property called `$field_types` in the Extend model. This let's you do `Extend::$field_types` and print out the available options for the custom fields. Right now it returns text, html, image, file.

It was discussed in #739 on [this comment](https://github.com/anchorcms/anchor-cms/pull/739#issuecomment-58581298) but I think it overlooked in my last PR.
