### PR TITLE
Change redirect on edit error (fields.php)

### DIFF
--- a/anchor/routes/fields.php
+++ b/anchor/routes/fields.php
@@ -134,7 +134,7 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 
 			Notify::error($errors);
 
-			return Response::redirect('admin/extend/fields/add');
+			return Response::redirect('admin/extend/fields/edit/' . $id);
 		}
 
 		if($input['field'] == 'image') {


### PR DESCRIPTION
Sorry for not having respected your contributing guidelines, but I foudn abug and corrected it directly from Github website. Plus, the bug I fixed is really simple to understand.

On error, the extend/fields/edit form redirects to extend/fields/add. My commit fixes it.

Thanks for your cool project!
