### PR TITLE
Fix for #635, now updates 'created' date on each post save

### DIFF
--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -117,13 +117,8 @@ Route::collection(array('before' => 'auth,csrf'), function() {
 
 			return Response::redirect('admin/posts/edit/' . $id);
 		}
-
-		if($input['created']) {
-			$input['created'] = Date::mysql($input['created']);
-		}
-		else {
-			unset($input['created']);
-		}
+		
+		$input['created'] = Date::mysql('now');
 
 		if(is_null($input['comments'])) {
 			$input['comments'] = 0;


### PR DESCRIPTION
This is my first ever pull request so I hope I'm doing it right.

I've fixed the #635 issue by having it save the current date and time each time a post's edited.
