### PR TITLE
XSS secure comment output

### DIFF
--- a/themes/default/article.php
+++ b/themes/default/article.php
@@ -24,7 +24,7 @@
 						<time><?php echo relative_time(comment_time()); ?></time>
 
 						<div class="content">
-							<?php echo comment_text(); ?>
+							<?php echo htmlspecialchars(comment_text()); ?>
 						</div>
 
 						<span class="counter"><?php echo $i; ?></span>


### PR DESCRIPTION
On line 27, if you enter comment like "&lt;script&gt;alert('hello');&lt;/script&gt;", it will no longer execute the alert.
Note : There is the same issue with posts (in theme/default/posts.php and theme/default/article.php) but I figured it's more a functionnality than a bug in the case of a post.
