### PR TITLE
Fix for #791

### DIFF
--- a/anchor/models/post.php
+++ b/anchor/models/post.php
@@ -60,6 +60,15 @@ class Post extends Base {
 				Base::table('users.bio as author_bio'),
 				Base::table('users.real_name as author_name')));
 
+		foreach ($posts as $key => $post) {
+			if ($post->data['status'] !== 'published') {
+				unset($posts[$key]);
+			}
+		}
+		if (count($posts) < 1) {
+			$total = 0;
+		}
+
 		return array($total, $posts);
 	}
 


### PR DESCRIPTION
Fixed issue with search system as described in #791 . Queries created
for search function would be like

```
WHERE `anchor_posts`.`status` = ? AND `anchor_posts`.`title` like ? OR
`anchor_posts`.`html` like ?
```

but if both the title and content of a post contain the search term,
the status check would be overwritten by the OR clause . The solution I
made is a bit ugly so the syntax may need some change, asked for it on
gitter but no replies. Anyway, this is a temporary fix.