### PR TITLE
Fix that makes it possible to use down() function in migrations

### DIFF
--- a/anchor/libraries/anchor.php
+++ b/anchor/libraries/anchor.php
@@ -113,6 +113,10 @@ class Anchor {
 			$number = $migrations->up($migrate_to);
 			Query::table($table)->where('key', '=', 'current_migration')->update(array('value' => $number));
 		}
+		else if($current > $migrate_to) {
+			$number = $migrations->down($migrate_to);
+			Query::table($table)->where('key', '=', 'current_migration')->update(array('value' => $number));
+		}
 	}
 
 }

--- a/anchor/libraries/migrations.php
+++ b/anchor/libraries/migrations.php
@@ -57,7 +57,7 @@ class Migrations {
 		return $num;
 	}
 
-	public function down() {
+	public function down($to) {
 		// reverse sorted migration files
 		$files = $this->files(true);
 


### PR DESCRIPTION
I've noticed that Anchor CMS couldn't actually handle the reverting of migrations when I was making a simple fork. The down() function of a migration was never called. Here's a fix for that!