### PR TITLE
non-english characters in slug

### DIFF
--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -15,14 +15,14 @@ function is_installed() {
 }
 
 function slug($string, $separator = '-') {
-	$accents_regex = '~&([a-z]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i';
+	$accents_regex = '~&([^\w_]{1,2})(?:acute|cedil|circ|grave|lig|orn|ring|slash|th|tilde|uml);~i';
 	$special_cases = array(
 		'&' => 'and'
 	);
 	$string = mb_strtolower(trim($string) , 'UTF-8');
 	$string = str_replace(array_keys($special_cases) , array_values($special_cases) , $string);
 	$string = preg_replace($accents_regex, '$1', htmlentities($string, ENT_QUOTES, 'UTF-8'));
-	$string = preg_replace("/[^a-z0-9]/u", "$separator", $string);
+	$string = preg_replace("/[^\w_0-9]/u", "$separator", $string);
 	$string = preg_replace("/[$separator]+/u", "$separator", $string);
 	$string = trim($string, '-');
 	return $string;

--- a/system/uri.php
+++ b/system/uri.php
@@ -127,8 +127,13 @@ class Uri {
 	public static function format($uri, $server) {
 		// Remove all characters except letters,
 		// digits and $-_.+!*'(),{}|\\^~[]`<>#%";/?:@&=.
-		$uri = filter_var(rawurldecode($uri), FILTER_SANITIZE_URL);
-
+		if(Config::app('language', 'en_GB') == 'ru_RU') {
+			// filter var doesn't like the Russian language using
+			// the previous setting.
+			$uri = filter_var(rawurldecode($uri));
+		} else {
+			$uri = filter_var(rawurldecode($uri), FILTER_SANITIZE_URL);
+		}
 
 		// remove script path/name
 		$uri = static::remove_script_name($uri, $server);


### PR DESCRIPTION
Solves the problem of cyrillic characters in search (#680) and, perhaps, the problem of domain name with cyrillic characters (#809 ?).

