### PR TITLE
bug fix for issue #774

### DIFF
--- a/anchor/functions/menus.php
+++ b/anchor/functions/menus.php
@@ -69,6 +69,7 @@ function menu_render($params = array()) {
 	// options
 	$parent = isset($params['parent']) ? $params['parent'] : 0;
 	$class = isset($params['class']) ? $params['class'] : 'active';
+	$index = isset($params['index']) ? $params['index'] : 0;
 
 	foreach($menu as $item) {
 		if($item->parent == $parent) {
@@ -78,10 +79,17 @@ function menu_render($params = array()) {
 
 			$html .= '<li>';
 			$html .= Html::link($item->relative_uri(), $item->name, $attr);
-			$html .= menu_render(array('parent' => $item->id));
+			$html .= menu_render(array('parent' => $item->id, 'index' => $menu->key()));
 			$html .= '</li>' . PHP_EOL;
 		}
 	}
+	// Reset our index before returning
+    $menu->rewind();
+    $menu->next();
+    while($index > 1){
+        $menu->next();
+        $index--;
+    }
 
 	if($html) $html = PHP_EOL . '<ul>' . PHP_EOL . $html . '</ul>' . PHP_EOL;
 


### PR DESCRIPTION
Menu_Render() does not provide expected output ( see issue #774 )

The index of the $menu (List<item>) being looped through in the ForEach loop is overwritten by subsequent calls to *menu_render()* from within the ForEach loop. To ensure every item in $menu is iterated over across every call of *menu_render()* I added a parameter to the method that tracks the parent's menu's index at the time of the *menu_render()* call. Before any children return, the index is reset to where the parent left off.

This is likely not the best way to do this, but it does provide a better result than the current implementation.