### PR TITLE
Bug: Fix uncaught exception

### DIFF
--- a/anchor/libraries/update.php
+++ b/anchor/libraries/update.php
@@ -48,11 +48,15 @@ class Update {
 
 	public static function touch() {
 		$url = 'http://anchorcms.com/version';
+		$result = false;
 
 		if(in_array(ini_get('allow_url_fopen'), array('true', '1', 'On'))) {
 			try {
 				$context = stream_context_create(array('http' => array('timeout' => 2)));
-				$result = file_get_contents($url, false, $context);
+				$result = @file_get_contents($url, false, $context);
+				if ( !$result ) {
+					$result = false;
+				}
 			} catch(Exception $e) {
 				$result = false;
 			}
@@ -69,9 +73,6 @@ class Update {
 			$result = curl_exec($session);
 
 			curl_close($session);
-		}
-		else {
-			$result = false;
 		}
 
 		return $result;


### PR DESCRIPTION
Fix uncaught exception which throws when user try to log first time and is offline. Call stack:

![snimek obrazovky 2015-03-30 v 0 37 24](https://cloud.githubusercontent.com/assets/374917/6888207/ed705c26-d676-11e4-9b00-8c543d432852.png)

@MacOS 10.10.2, PHP 5.5.22, Apache 2.4.9, Anchor 0.9.2