### PR TITLE
Fix path for image uploads

### DIFF
--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -231,7 +231,7 @@ Route::post('admin/upload', array('before' => 'auth', 'main' => function() {
 	$uploader = new Uploader(PATH . 'content', array('png', 'jpg', 'bmp', 'gif', 'pdf'));
 	$filepath = $uploader->upload($_FILES['file']);
 
-	$uri = Config::app('url', '/') . '/content/' . basename($filepath);
+	$uri = Config::app('url', '/') . 'content/' . basename($filepath);
 	$output = array('uri' => $uri);
 
 	return Response::json($output);


### PR DESCRIPTION
Fixes an issue with image upload path returning `//content/` incorrectly instead of `/content/`.

As I noted [on the forum](http://forums.anchorcms.com/releases/0-10-testing/?page=1#post-6141) I'm not 100% if this is just an issue on my installation or not — if it is just me, just close this.

