### PR TITLE
Added fully qualified namespacing

### DIFF
--- a/system/database/query.php
+++ b/system/database/query.php
@@ -287,7 +287,7 @@ class Query extends Builder {
 	 * @return object
 	 */
 	public function join($table, $left, $operator, $right, $type = 'INNER') {
-		if($table instanceof Closure) {
+		if($table instanceof \Closure) {
 			list($query, $alias) = $table();
 
 			$this->bind = array_merge($this->bind, $query->bind);

--- a/system/route.php
+++ b/system/route.php
@@ -59,7 +59,7 @@ class Route {
 	public static function register($method, $patterns, $arguments) {
 		$method = strtoupper($method);
 
-		if($arguments instanceof Closure) {
+		if($arguments instanceof \Closure) {
 			$arguments = array('main' => $arguments);
 		}
 
@@ -156,12 +156,12 @@ class Route {
 		$this->after($response);
 
 		// If the response was a view get the output and create response
-		if($response instanceof View) {
+		if($response instanceof \System\View) {
 			return Response::create($response->render());
 		}
 
 		// If we have a response object return it
-		if($response instanceof Response) {
+		if($response instanceof \System\Response) {
 			return $response;
 		}
 


### PR DESCRIPTION
Fixed issues with [PR 789](https://github.com/anchorcms/anchor-cms/pull/789) that didn't follow the contributing guidelines.

"Anchor works wonderfully on HHVM v3.4.0 and sees a pretty great performance increase.
The only change required is that HHVM requires instanceof constructs be used with fully qualified class names instead of relative class names.
This is a non-breaking change and works for both the PHP and HHVM interpreters."