### PR TITLE
Autosave feature implemented

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -214,8 +214,9 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		Extend::process('page', $page->id);
 
 		Notify::success(__('pages.created'));
-
-		return Response::redirect('admin/pages');
+		
+		if(Input::get('autosave') === 'true') return Response::redirect('admin/pages/edit/' . $page->id);
+		else return Response::redirect('admin/pages');
 	});
 
 	/*

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -257,8 +257,9 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		Extend::process('post', $post->id);
 
 		Notify::success(__('posts.created'));
-
-		return Response::redirect('admin/posts');
+		
+		if(Input::get('autosave') === 'true') return Response::redirect('admin/posts/edit/' . $page->id);
+		else return Response::redirect('admin/posts');
 	});
 
 	/*

--- a/anchor/views/assets/css/admin.css
+++ b/anchor/views/assets/css/admin.css
@@ -189,6 +189,7 @@ hgroup {
 	font-size: 13px;
 	line-height: 38px;
 	font-weight: bold;
+	text-align: center;
 
 	border: none;
 	border-radius: 5px;

--- a/anchor/views/assets/css/admin.css
+++ b/anchor/views/assets/css/admin.css
@@ -514,7 +514,7 @@ body.login {
 		font-weight: lighter;
 
 		float: left;
-		width: 600px;
+		width: 580px;
 		padding: 30px 0;
 
 		background: transparent;

--- a/anchor/views/assets/js/autosave.js
+++ b/anchor/views/assets/js/autosave.js
@@ -11,7 +11,6 @@ $(document).ready(function() {
 	var secondsPassed = 0;
 	
 	var onInterval = function() {
-		console.log("interval!");
 		secondsPassed++;
 		if(secondsPassed > maxSeconds) {
 			secondsPassed = 0;
@@ -39,7 +38,7 @@ $(document).ready(function() {
 	
 	$(".autosave-action").click(function() {
 		if(autosaveInterval === null) {
-			autosaveInterval = setInterval(function() {onInterval()}, 1000);
+			autosaveInterval = setInterval(function() {onInterval();}, 1000);
 		} else {
 			clearInterval(autosaveInterval);
 			autosaveInterval = null;

--- a/anchor/views/assets/js/autosave.js
+++ b/anchor/views/assets/js/autosave.js
@@ -25,6 +25,11 @@ $(document).ready(function() {
 	
 	var alterAutosaveActionButton = function() {
 		var pressOn = (autosaveInterval !== null);
+		$(".autosave-action").toggleClass("green", pressOn);
+		$(".autosave-action").toggleClass("autosave-on", pressOn);
+		$(".autosave-action").toggleClass("secondary", !pressOn);
+		$(".autosave-label").text(pressOn ? "Autosave in 30" : "Autosave: Off");
+		/*
 		if(pressOn) { // Just turned on autosave
 			$(".autosave-action").addClass("green");
 			$(".autosave-action").removeClass("secondary");
@@ -34,6 +39,7 @@ $(document).ready(function() {
 			$(".autosave-action").removeClass("green");
 			$(".autosave-label").text("Autosave: Off");
 		}
+		*/
 	};
 	
 	$(".autosave-action").click(function() {

--- a/anchor/views/assets/js/autosave.js
+++ b/anchor/views/assets/js/autosave.js
@@ -1,0 +1,50 @@
+/**
+ * From @TheBrenny:
+ *      This JS File holds the functions that are used to determine whether or
+ *      not we should turn on/off autosave, and determines whether or not
+ *      autosave is active.
+ */
+
+$(document).ready(function() {
+	var autosaveInterval;
+	var maxSeconds = 30;
+	var secondsPassed = 0;
+	
+	var onInterval = function() {
+		console.log("interval!");
+		secondsPassed++;
+		if(secondsPassed > maxSeconds) {
+			secondsPassed = 0;
+			submitDocument();
+		}
+		$(".autosave-label").text("Autosave in " + (maxSeconds - secondsPassed));
+	};
+	
+	var submitDocument = function() {
+		$("form").first().trigger("submit");
+	};
+	
+	var alterAutosaveActionButton = function() {
+		var pressOn = (autosaveInterval !== null);
+		if(pressOn) { // Just turned on autosave
+			$(".autosave-action").addClass("green");
+			$(".autosave-action").removeClass("secondary");
+			$(".autosave-label").text("Autosave in 30");
+		} else { // Just turned off autosave
+			$(".autosave-action").addClass("secondary");
+			$(".autosave-action").removeClass("green");
+			$(".autosave-label").text("Autosave: Off");
+		}
+	};
+	
+	$(".autosave-action").click(function() {
+		if(autosaveInterval === null) {
+			autosaveInterval = setInterval(function() {onInterval()}, 1000);
+		} else {
+			clearInterval(autosaveInterval);
+			autosaveInterval = null;
+			secondsPassed = 0;
+		}
+		alterAutosaveActionButton();
+	});
+});

--- a/anchor/views/assets/js/editor.js
+++ b/anchor/views/assets/js/editor.js
@@ -195,7 +195,8 @@
 	// AJAX form submit
 	form.on('submit', function() {
 		var data = $(this).serializeArray();
-
+		var didAutosave = $(".autosave-action").hasClass("autosave-on");
+		
 		submit.prop('disabled', true).css('cursor', 'wait').html(submitProgress);
 
 		document.title = submitProgress;
@@ -203,7 +204,7 @@
 		$.ajax({
 			url: form.attr('action'),
 			type: "POST",
-			data: data,
+			data: data + "&autosave=" + didAutosave,
 			success: function(data, textStatus, jqXHR) {
 
 				var notification = $(data).find('.notifications').clone(true),
@@ -218,8 +219,8 @@
 						opacity: 0
 					}, 600, "ease-out", function() {
 						if ($('.btn.delete').length === 0 && $(this).find('.error').length === 0) {
-							// redirect to posts or pages list on success if we are not in edit/update mode
-							window.location.href = activeMenu.attr('href');
+							// redirect to the redirect page on success if we are not in edit/update mode
+							window.location.href = jqXHR.responseURL;
 						}
 						$(this).remove();
 					});

--- a/anchor/views/assets/js/redirect.js
+++ b/anchor/views/assets/js/redirect.js
@@ -4,7 +4,7 @@
 $(function() {
 	var fieldset = $('fieldset.redirect'),
 		input = $('input[name=redirect]'),
-		btn = $('button.secondary');
+		btn = $('button.secondary.redirector');
 
 	var toggle = function() {
 		fieldset.toggleClass('show');

--- a/anchor/views/pages/add.php
+++ b/anchor/views/pages/add.php
@@ -19,9 +19,9 @@
 					'type' => 'submit',
 					'class' => 'btn'
 				)); ?>
-
+				<a class="btn autosave-action autosave-label secondary" style="width: 154px;">Autosave: Off</a>
 				<?php echo Form::button(__('pages.redirect'), array(
-					'class' => 'btn secondary'
+					'class' => 'btn secondary redirector'
 				)); ?>
 			</aside>
 		</div>

--- a/anchor/views/pages/add.php
+++ b/anchor/views/pages/add.php
@@ -104,6 +104,7 @@
 <script src="<?php echo asset('anchor/views/assets/js/upload-fields.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/text-resize.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/editor.js'); ?>"></script>
+<script src="<?php echo asset('anchor/views/assets/js/autosave.js'); ?>"></script>
 <script>
 	$('textarea[name=markdown]').editor();
 	$('#pagetype').on('change', function() {

--- a/anchor/views/pages/edit.php
+++ b/anchor/views/pages/edit.php
@@ -109,6 +109,7 @@
 <script src="<?php echo asset('anchor/views/assets/js/text-resize.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/editor.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/change-saver.js'); ?>"></script>
+<script src="<?php echo asset('anchor/views/assets/js/autosave.js'); ?>"></script>
 <script>
 	$('textarea[name=markdown]').editor();
 	$('#pagetype').on('change', function() {

--- a/anchor/views/pages/edit.php
+++ b/anchor/views/pages/edit.php
@@ -19,11 +19,11 @@
 					'type' => 'submit',
 					'class' => 'btn'
 				)); ?>
-
+				<a class="btn autosave-action autosave-label secondary" style="width: 154px;">Autosave: Off</a>
 				<?php echo Form::button(__('pages.redirect'), array(
-					'class' => 'btn secondary'
+					'class' => 'btn secondary redirector'
 				)); ?>
-
+				
 				<?php
 				if($deletable == true) {
 					echo Html::link('admin/pages/delete/' . $page->id, __('global.delete'), array(

--- a/anchor/views/posts/add.php
+++ b/anchor/views/posts/add.php
@@ -87,6 +87,7 @@
 <script src="<?php echo asset('anchor/views/assets/js/upload-fields.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/text-resize.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/editor.js'); ?>"></script>
+<script src="<?php echo asset('anchor/views/assets/js/autosave.js'); ?>"></script>
 <script>
 	$('textarea[name=markdown]').editor();
 </script>

--- a/anchor/views/posts/add.php
+++ b/anchor/views/posts/add.php
@@ -20,6 +20,7 @@
 					'class' => 'btn',
 					'data-loading' => __('global.saving')
 				)); ?>
+				<a class="btn autosave-action autosave-label secondary" style="width: 154px;">Autosave: Off</a>
 			</aside>
 		</div>
 	</fieldset>

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -19,7 +19,7 @@
 					'type' => 'submit',
 					'class' => 'btn'
 				)); ?>
-
+				<a class="btn autosave-action autosave-label secondary" style="width: 154px;">Autosave: Off</a>
 				<?php echo Html::link('admin/posts/delete/' . $article->id, __('global.delete'), array(
 					'class' => 'btn delete red'
 				)); ?>

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -95,6 +95,7 @@
 <script src="<?php echo asset('anchor/views/assets/js/text-resize.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/editor.js'); ?>"></script>
 <script src="<?php echo asset('anchor/views/assets/js/change-saver.js'); ?>"></script>
+<script src="<?php echo asset('anchor/views/assets/js/autosave.js'); ?>"></script>
 <script>
     $('textarea[name=markdown]').editor();
     $('form').changeSaver('textarea[name=markdown]');


### PR DESCRIPTION
Closes issue #879, however, some changes may need to be made to a few things.

When autosaving a new article/page (ie. when adding a new article/page) after the first autosave, you will be redirected back to the posts/pages index page. This seems like a bug, but you can easily just go back to the article/page you were writing, turn on autosave, and continue as normal.

I edited the pages' redirect button, at the time, if any `<button class="secondary"></button>` had been pressed, it would make the page a redirector page. I noticed this while testing out the autosave feature, and decided to fix it.

There may be other bugs, however, I see none.