### PR TITLE
Part 2, the child/parent system should work on the admin pages page

### DIFF
--- a/anchor/functions/menus.php
+++ b/anchor/functions/menus.php
@@ -25,38 +25,72 @@ function menu_items() {
 /*
 	Object props
 */
-function menu_id() {
-	return Registry::prop('menu_item', 'id');
+function menu_id($menu_item = null) {
+	return ($menu_item ? $menu_item->id : Registry::prop('menu_item', 'id'));
 }
 
-function menu_url() {
-	if($page = Registry::get('menu_item')) {
-		return $page->uri();
+function menu_url($menu_item = null) {
+	if(!$menu_item) {
+		$menu_item = Registry::get('menu_item');
+	}
+	if($menu_item) {
+		return $menu_item->uri();
 	}
 }
 
-function menu_relative_url() {
-	if($page = Registry::get('menu_item')) {
-		return $page->relative_uri();
+function menu_relative_url($menu_item = null) {
+	if(!$menu_item) {
+		$menu_item = Registry::get('menu_item');
+	}
+	if($menu_item) {
+		return $menu_item->relative_uri();
 	}
 }
 
-function menu_name() {
-	return Registry::prop('menu_item', 'name');
+function menu_name($menu_item = null) {
+	return ($menu_item ? $menu_item->name : Registry::prop('menu_item', 'name'));
 }
 
-function menu_title() {
-	return Registry::prop('menu_item', 'title');
+function menu_title($menu_item = null) {
+	return ($menu_item ? $menu_item->title : Registry::prop('menu_item', 'title'));
 }
 
-function menu_active() {
-	if($page = Registry::get('menu_item')) {
-		return $page->active();
+function menu_active($menu_item = null) {
+	if(!$menu_item) {
+		$menu_item = Registry::get('menu_item');
+	}
+	if($menu_item) {
+		return $menu_item->active();
 	}
 }
 
-function menu_parent() {
-	return Registry::prop('menu_item', 'parent');
+function menu_parent($menu_item = null) {
+	return ($menu_item ? $menu_item->parent : Registry::prop('menu_item', 'parent'));
+}
+
+function menu_has_children($parent = null) {
+	foreach(get_menus_children($parent) as $c) return 1; // Returns true if there is atleast 1 child
+	return 0;
+}
+
+function get_menus_children($parent = null) {
+	$menu_item = menu_id($parent);
+	$menu = clone Registry::get('menu');
+	$menu->rewind();
+	$children = array();
+	
+	foreach($menu as $item) {
+		if($item->parent == $menu_item) $children[] = $item;
+	}
+	
+	return $children;
+}
+
+function is_child_active($parent = null) {
+	foreach(get_menus_children($parent) as $child) {
+		if($child->active()) return 1;
+	}
+	return 0;
 }
 
 /*
@@ -73,9 +107,9 @@ function menu_render($params = array()) {
 	foreach($menu as $item) {
 		if($item->parent == $parent) {
 			$attr = array();
-
+			
 			if($item->active()) $attr['class'] = $class;
-
+			
 			$html .= '<li>';
 			$html .= Html::link($item->relative_uri(), $item->name, $attr);
 			$html .= menu_render(array('parent' => $item->id));

--- a/anchor/functions/menus.php
+++ b/anchor/functions/menus.php
@@ -26,10 +26,12 @@ function menu_items() {
 	Object props
 */
 function menu_id($menu_item = null) {
+	if(is_array($menu_item)) return $menu_item['id'];
 	return ($menu_item ? $menu_item->id : Registry::prop('menu_item', 'id'));
 }
 
 function menu_url($menu_item = null) {
+	if(is_array($menu_item)) $menu_item = get_menu_item('id', $menu_item);
 	if(!$menu_item) {
 		$menu_item = Registry::get('menu_item');
 	}
@@ -39,6 +41,7 @@ function menu_url($menu_item = null) {
 }
 
 function menu_relative_url($menu_item = null) {
+	if(is_array($menu_item)) $menu_item = get_menu_item('id', $menu_item);
 	if(!$menu_item) {
 		$menu_item = Registry::get('menu_item');
 	}
@@ -48,14 +51,17 @@ function menu_relative_url($menu_item = null) {
 }
 
 function menu_name($menu_item = null) {
+	if(is_array($menu_item)) return $menu_item['name'];
 	return ($menu_item ? $menu_item->name : Registry::prop('menu_item', 'name'));
 }
 
 function menu_title($menu_item = null) {
+	if(is_array($menu_item)) return $menu_item['title'];
 	return ($menu_item ? $menu_item->title : Registry::prop('menu_item', 'title'));
 }
 
 function menu_active($menu_item = null) {
+	if(is_array($menu_item)) $menu_item = get_menu_item('id', $menu_item);
 	if(!$menu_item) {
 		$menu_item = Registry::get('menu_item');
 	}
@@ -65,6 +71,8 @@ function menu_active($menu_item = null) {
 }
 
 function menu_parent($menu_item = null) {
+	
+	if(is_array($menu_item)) return $menu_item['parent'];
 	return ($menu_item ? $menu_item->parent : Registry::prop('menu_item', 'parent'));
 }
 
@@ -91,6 +99,17 @@ function is_child_active($parent = null) {
 		if($child->active()) return 1;
 	}
 	return 0;
+}
+
+/*
+	Menu Item Getters
+*/
+function get_menu_item($feature_type, $menu_feature) {
+	if(is_array($menu_feature)) $menu_feature = $menu_feature[$feature_type];
+	$menu = clone Registry::get('menu');
+	foreach($menu as $page) {
+		if($page->{$feature_type} == $menu_feature) return $page;
+	}
 }
 
 /*

--- a/anchor/functions/pages.php
+++ b/anchor/functions/pages.php
@@ -3,22 +3,28 @@
 /**
  *	Theme functions for pages
  */
-function page_id() {
-	return Registry::prop('page', 'id');
+function page_id($page_item = null) {
+	if(is_array($page_item)) return $page_item['id'];
+	return ($page_item ? $page_item->id : Registry::prop('page', 'id'));
 }
 
-function page_url() {
-	if($page = Registry::get('page')) {
-		return $page->uri();
+function page_url($page_item = null) {
+	if(!$page_item) {
+		$page_item = Registry::get('page');
+	}
+	if($page_item) {
+		return $page_item->uri();
 	}
 }
 
-function page_slug() {
-	return Registry::prop('page', 'slug');
+function page_slug($page_item = null) {
+	if(is_array($page_item)) return $page_item['slug'];
+	return ($page_item ? $page_item->slug : Registry::prop('page', 'slug'));
 }
 
-function page_name() {
-	return Registry::prop('page', 'name');
+function page_name($page_item = null) {
+	if(is_array($page_item)) return $page_item['name'];
+	return ($page_item ? $page_item->name : Registry::prop('page', 'name'));
 }
 
 function page_title($default = '') {
@@ -33,12 +39,14 @@ function page_title($default = '') {
 	return $default;
 }
 
-function page_content() {
-	return Registry::prop('page', 'html');
+function page_content($page_item = null) {
+	if(is_array($page_item)) return $page_item['html'];
+	return ($page_item ? $page_item->html : Registry::prop('page', 'html'));
 }
 
-function page_status() {
-	return Registry::prop('page', 'status');
+function page_status($page_item = null) {
+	if(is_array($page_item)) return $page_item['status'];
+	return ($page_item ? $page_item->status : Registry::prop('page', 'status'));
 }
 
 function page_custom_field($key, $default = '') {

--- a/anchor/views/pages/index.php
+++ b/anchor/views/pages/index.php
@@ -26,54 +26,61 @@
 	</nav>
 
 	<?php if($pages->count): ?>
-	<ul class="main list">
-		<?php
-		$outerarray = array();
-		foreach($pages->results as $page):
-			$innerarray = array('id' => $page->id,'name' => $page->name,'slug' => $page->slug,'status' => $page->status,'parent' => $page->parent);
-			array_push($outerarray,$innerarray);
-		endforeach; ?>
-		<?php
-			$i = 0;
-			foreach($outerarray as $in => $arr):
-        		if ($arr['parent'] != 0){
-        			$temp = $arr;
-        			unset($outerarray[$in]);
-        			foreach($outerarray as $in2 => $arr2):
-        				$i++;
-	        			if ($arr2['id'] == $temp['parent']){
-	        				array_splice($outerarray, $i, 0, array($temp));
-	        				$i = 0;
-	        				break;
-	        			}
-	        		endforeach;
-        		}
-    		endforeach;
-    	foreach($outerarray as $in => $arr): ?>
-		<li>
-
-			<a href="<?php echo Uri::to('admin/pages/edit/' . $arr['id']); ?>">
-				<?php
-						if ($arr['parent'] != 0)
-							echo '<div class="indent">';
-						else
-							echo '<div>';
-				?>
-				<strong><?php echo $arr['name']; ?></strong>
-				<span>
-					<?php echo $arr['slug']; ?>
-					<em class="status <?php echo $arr['status']; ?>" title="<?php echo __('global.' . $arr['status']); ?>">
-						<?php echo __('global.' . $arr['status']); ?>
-					</em>
-				</span>
-				</div>
-			</a>
-		</li>
-		<?php endforeach; ?>
-	</ul>
-
-	<aside class="paging"><?php echo $pages->links(); ?></aside>
-
+		<ul class="main list">
+			<?php $child_pages = array(); // Will hold pages that are only children of other pages
+			foreach($pages->results as $page) :
+				if(menu_parent($page) != 0) $child_pages[] = clone $page;
+			endforeach;
+			foreach($pages->results as $page) : ?>
+				<?php if(menu_has_children($page)) : ?>
+					<li>
+						<a href="<?php echo Uri::to('admin/pages/edit/' . menu_id($page)); ?>">
+							<div>
+								<strong><?php echo menu_name($page); ?></strong>
+								<span>
+									<?php echo page_slug($page); ?>
+									<em class="status <?php echo page_status($page); ?>" title="<?php echo __('global.' . page_status($page)); ?>">
+										<?php echo __('global.' . page_status($page)); ?>
+									</em>
+								</span>
+							</div>
+						</a>
+					</li>
+					<?php foreach($child_pages as $child) :
+						if(menu_parent($child) == menu_id($page)) : ?>
+							<li>
+								<a href="<?php echo Uri::to('admin/pages/edit/' . menu_id($child)); ?>">
+									<div class="indent">
+										<strong><?php echo menu_name($child); ?></strong>
+										<span>
+											<?php echo page_slug($child); ?>
+											<em class="status <?php echo page_status($child); ?>" title="<?php echo __('global.' . page_status($child)); ?>">
+												<?php echo __('global.' . page_status($child)); ?>
+											</em>
+										</span>
+									</div>
+								</a>
+							</li>
+						<?php endif;
+					endforeach;
+				elseif(menu_parent($page) == 0) : ?>
+					<li>
+						<a href="<?php echo Uri::to('admin/pages/edit/' . menu_id($page)); ?>">
+							<div>
+								<strong><?php echo menu_name($page); ?></strong>
+								<span>
+									<?php echo page_slug($page); ?>
+									<em class="status <?php echo page_status($page); ?>" title="<?php echo __('global.' . page_status($page)); ?>">
+										<?php echo __('global.' . page_status($page)); ?>
+									</em>
+								</span>
+							</div>
+						</a>
+					</li>
+				<?php endif;
+			endforeach; ?>
+		</ul>
+		<aside class="paging"><?php echo $pages->links(); ?></aside>
 	<?php else: ?>
 	<aside class="empty pages">
 		<span class="icon"></span>


### PR DESCRIPTION
This is Part 1 to fix the issue of #839. The main issue is within the child/parent system that has been implemented, or lack of. Hopefully a dev member can come around and make this function and look a little nicer compared to what I see... :+1:

Note: In contrast to what GitHub reckons has been altered, not a lot has, to be quite honest. All it is, is just adding defaulted parameters to most of the methods of the `anchor/functions/menus.php` functions, which allow for a Page to be passed through.

Obviously there will need to be an error checker somewhere in there, otherwise it may be that if you pass something without those attributes a fatal error will occur.

Cheers. :+1: :v: