### PR TITLE
Excluded certain fields from being encoded

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -85,7 +85,11 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		// convert to ascii
 		$input['slug'] = slug($input['slug']);
 		
+		// an array of items that we shouldn't encode - they're no XSS threat
+		$dont_encode = array('markdown');
+		
 		foreach($input as $key => &$value) {
+			if(in_array($key, $dont_encode)) continue;
 			$value = eq($value);
 		}
 		
@@ -172,7 +176,11 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		// convert to ascii
 		$input['slug'] = slug($input['slug']);
 		
+		// an array of items that we shouldn't encode - they're no XSS threat
+		$dont_encode = array('markdown');
+		
 		foreach($input as $key => &$value) {
+			if(in_array($key, $dont_encode)) continue;
 			$value = eq($value);
 		}
 		

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -118,7 +118,11 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		// convert to ascii
 		$input['slug'] = slug($input['slug']);
 		
+		// an array of items that we shouldn't encode - they're no XSS threat
+		$dont_encode = array('description', 'markdown', 'css', 'js');
+		
 		foreach($input as $key => &$value) {
+			if(in_array($key, $dont_encode)) continue;
 			$value = eq($value);
 		}
 		
@@ -210,7 +214,11 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		// convert to ascii
 		$input['slug'] = slug($input['slug']);
 		
+		// an array of items that we shouldn't encode - they're no XSS threat
+		$dont_encode = array('description', 'markdown', 'css', 'js');
+		
 		foreach($input as $key => &$value) {
+			if(in_array($key, $dont_encode)) continue;
 			$value = eq($value);
 		}
 		

--- a/anchor/views/pages/edit.php
+++ b/anchor/views/pages/edit.php
@@ -45,7 +45,7 @@
 
 	<fieldset class="main">
 		<div class="wrap">
-			<?php echo Form::textarea('markdown', Input::previous('markdown', htmlentities($page->markdown, ENT_QUOTES, 'UTF-8')), array(
+			<?php echo Form::textarea('markdown', Input::previous('markdown', $page->markdown), array(
 				'placeholder' => __('pages.content_explain')
 			)); ?>
 

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -29,7 +29,7 @@
 
 	<fieldset class="main">
 		<div class="wrap">
-			<?php echo Form::textarea('markdown', Input::previous('markdown', htmlentities($article->markdown, ENT_QUOTES, 'UTF-8')), array(
+			<?php echo Form::textarea('markdown', Input::previous('markdown', $article->markdown), array(
 				'placeholder' => __('posts.content_explain')
 			)); ?>
 


### PR DESCRIPTION
This should fix the issue where everything would become unreadable in the editor (#894).

This, to me, seems like the appropriate fix, and has been tested on my anchor-tester Cloud9 VM. You can view that here: http://anchortester-mastercork889.c9.io

Cheers, Brenny. :v: