### PR TITLE
Custom fields were unable to be created; now they can be

### DIFF
--- a/anchor/routes/fields.php
+++ b/anchor/routes/fields.php
@@ -41,7 +41,10 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		
 		$input['key'] = slug($input['key'], '_');
 		
+		$dont_encode = array('attributes');
+		
 		foreach($input as $key => &$value) {
+			if(in_array($key, $dont_encode)) continue;
 			$value = eq($value);
 		}
 		


### PR DESCRIPTION
This bugfix fixes issue #895.

Thanks to @Lewitje for pointing this out. I had no idea that you could stack up form items in an array. This error came from my previous fix to prevent stored XSS (#883), however I think I went a bit overboard on it. Anymore of these sorts of findings would be largely appreciated!

Cheers, Brenny. :v: