### PR TITLE
Fixing error on page creation

### DIFF
--- a/install/storage/anchor.sql
+++ b/install/storage/anchor.sql
@@ -54,7 +54,7 @@ CREATE TABLE `{{prefix}}pages` (
   `status` enum('draft','published','archived') NOT NULL,
   `redirect` text NOT NULL,
   `show_in_menu` tinyint(1) NOT NULL,
-  `menu_order` int(4) NOT NULL,
+  `menu_order` int(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `status` (`status`),
   KEY `slug` (`slug`)


### PR DESCRIPTION
When creating a new page, there is an mysql error: menu_order has no default value. This fixes it and everything still works fine (creating pages, the menu ordering etc)