### PR TITLE
The utf8_unicode_ci encoding sorts chars as expected

### DIFF
--- a/install/views/database.php
+++ b/install/views/database.php
@@ -62,7 +62,7 @@
 				<label for="collation">Collation</label>
 				<select id="collation" class="chosen-select" name="collation">
 					<?php foreach($collations as $code => $collation): ?>
-					<?php $selected = ($code == Input::previous('collation', 'utf8_general_ci')) ? ' selected' : ''; ?>
+					<?php $selected = ($code == Input::previous('collation', 'utf8_unicode_ci')) ? ' selected' : ''; ?>
 					<option value="<?php echo $code; ?>" <?php echo $selected; ?>>
 						<?php echo $code; ?>
 					</option>


### PR DESCRIPTION
So unicode_ci should be the default as anchor-cms is meant to be a cms for all languages.
See also [this excellent article](http://stackoverflow.com/questions/766809/whats-the-difference-between-utf8-general-ci-and-utf8-unicode-ci) on Stackoverflow