### PR TITLE
Pagetype templates

### DIFF
--- a/anchor/libraries/template.php
+++ b/anchor/libraries/template.php
@@ -13,6 +13,11 @@ class Template extends View {
 					$template .= '-' . $item->slug;
 				} elseif (is_readable($base . $template . 's/' . $template . '-' . $item->slug . EXT)) {
 					$template .= 's/' . $template . '-' . $item->slug;
+				} elseif (is_readable($base . $item->pagetype . EXT)) {
+					$template = $item->pagetype;
+					if (is_readable($base . $item->pagetype . '-' . $item->slug . EXT)) {
+						$template .= '-' . $item->slug;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If there exists a template named like the given custom page type, anchor will include it instead of the default page template.
With this, you can create for example a custom page type "gallery", for picture galleries, which need a unique template with the required markup and JS.