### PR TITLE
escaped text printed in input in Extend::html()

### DIFF
--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -86,7 +86,7 @@ class Extend extends Base {
 		switch($item->field) {
 			case 'text':
 				$value = isset($item->value->text) ? $item->value->text : '';
-				$html = '<input id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="text" value="' . $value . '">';
+				$html = '<input id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="text" value="' . htmlentities($value) . '">';
 				break;
 
 			case 'html':


### PR DESCRIPTION
in anchor/models/extend.php $value in <input> tag isn't escaped. so when $value contains double quotes, it ends up breaking the document markup.