### PR TITLE
Fixed an issue that could cause infinite redirect

### DIFF
--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -13,5 +13,5 @@ Options -indexes
 </IfModule>
 
 <IfModule !mod_rewrite.c>
-	ErrorDocument 404 index.php
+	ErrorDocument 404 /index.php
 </IfModule>


### PR DESCRIPTION
On some distributions of Apache, this .htaccess file would cause an self-referencing redirect to a blank page that said "index.php" in unformatted text. Adding the slash fixes this problem and sends the user to the theme's php-generated 404 page.