### PR TITLE
Fixed "Uncaught Exception" when updating a page type

### DIFF
--- a/anchor/routes/pagetypes.php
+++ b/anchor/routes/pagetypes.php
@@ -33,25 +33,20 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		
 		$input['key'] = slug($input['key'], '_');
 		
-		foreach($input as $key => &$value) {
-			$value = eq($value);
-		}
-		
 		$validator = new Validator($input);
 
 		$validator->add('valid_key', function($str) {
-			if(strlen($str) > 7) {
-				return Query::table(Base::table('pagetypes'))
-					->where('key', '=', $str)
-					->count() == 0;
-			}
-
-			return true;
+			return Query::table(Base::table('pagetypes'))
+			->where('key', '=', $str)
+			->count() == 0;
 		});
 
 		$validator->check('key')
-			->is_max(2, __('extend.name_missing'))
-			->is_valid_key(__('extend.name_exists'));
+			->is_max(2, __('extend.key_missing'))
+			->is_valid_key(__('extend.key_exists'));
+
+		$validator->check('value')
+			->is_max(1, __('extend.name_missing'));
 
 		if($errors = $validator->errors()) {
 			Input::flash();
@@ -74,6 +69,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 	Route::get('admin/extend/pagetypes/edit/(:any)', function($key) {
 		$vars['messages'] = Notify::read();
 		$vars['token'] = Csrf::token();
+
 		$vars['pagetype'] = Query::table(Base::table('pagetypes'))->where('key', '=', $key)->fetch();
 
 		return View::create('extend/pagetypes/edit', $vars)
@@ -86,23 +82,21 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function() {
 		
 		$input['key'] = slug($input['key'], '_');
 		
-		foreach($input as $key => &$value) {
-			$value = eq($value);
-		}
-		
 		$validator = new Validator($input);
 
 		$validator->add('valid_key', function($str) use($key) {
 			// no change
 			if($str == $key) return true;
-
 			// check the new key $str is available
 			return Query::table(Base::table('pagetypes'))->where('key', '=', $str)->count() == 0;
 		});
 
 		$validator->check('key')
-			->is_max(2, __('extend.name_missing'))
-			->is_valid_key(__('extend.name_exists'));
+			->is_max(2, __('extend.key_missing'))
+			->is_valid_key(__('extend.key_exists'));
+
+		$validator->check('value')
+			->is_max(1, __('extend.name_missing'));
 
 		if($errors = $validator->errors()) {
 			Input::flash();

--- a/anchor/views/extend/pagetypes/index.php
+++ b/anchor/views/extend/pagetypes/index.php
@@ -11,7 +11,7 @@
 <section class="wrap">
 	<?php echo $messages; ?>
 
-	<?php if(count($pagetypes) > 1): ?>
+	<?php if(count($pagetypes) >= 1): ?>
 	<ul class="list">
 		<?php foreach($pagetypes as $type): ?>
 		<li>


### PR DESCRIPTION
This pull request fix the issue https://github.com/anchorcms/anchor-cms/issues/939

I solved some problems when adding and updating a page type in the "extend" section:

- Display "All pages" pagetype at the beginning when there isn't another page added
- Empty field validation for all fields (adding and updating)
- Duplicates when create the same page
- Validation of primary key slug (key)
- Fix uncaught exception

@CraigChilds94. I hope this will help. If you need to change anything please let me know.

You can test the demo here:

http://visiopro.com.ve/site/anchor/admin

User: admin
Pass: 123456