### PR TITLE
Layout fix for translations: CSS code for pl-PL

### DIFF
--- a/anchor/views/assets/css/admin.css
+++ b/anchor/views/assets/css/admin.css
@@ -812,3 +812,24 @@ input[type='range'], ::-webkit-slider-thumb {
 	.indent{
 		padding-left: 40px;
 	}
+
+
+/*
+	Adition CSS code for translations 
+*/
+
+/*
+	menu fix for polis users, require class "pl-PL" in body tag 
+*/
+
+.pl-PL  .top .logo {
+	margin-right: 10px;
+}
+
+.pl-PL .top nav a {
+	margin-right: 5px;
+}
+
+.pl-PL .top .btn {
+	margin-left: 10px;
+}


### PR DESCRIPTION
Margins need to be smaller to keep menu in one line with Polish
translations.
Additional CSS code require the pl-PL class in body.