### PR TITLE
Remove undefined variable in routes file

### DIFF
--- a/install/routes.php
+++ b/install/routes.php
@@ -178,9 +178,9 @@ Route::get('account', array('before' => 'check', 'main' => function () {
         return Response::redirect('metadata');
     }
 
-    
+    $vars['messages'] = Notify::read();
 
-    return Layout::create('account',);
+    return Layout::create('account', $vars);
 }));
 
 Route::post('account', array('before' => 'check', 'main' => function () {

--- a/install/routes.php
+++ b/install/routes.php
@@ -180,7 +180,7 @@ Route::get('account', array('before' => 'check', 'main' => function () {
 
     
 
-    return Layout::create('account', $vars);
+    return Layout::create('account',);
 }));
 
 Route::post('account', array('before' => 'check', 'main' => function () {


### PR DESCRIPTION
### Fix for #1035 

Add the line missing from the routes file (mentioned in issue) so the $vars exception is not thrown

### Changes proposed:

- Added `$vars['messages'] = Notify::read();` to line 181 of the routes file

@protomorph Sorry, couldn't see your PR so created my own.