### PR TITLE
Fix Database Existence Crashes + Install Failures

### DIFF
--- a/anchor/migrations/212_insert_default_dashboard_meta_key.php
+++ b/anchor/migrations/212_insert_default_dashboard_meta_key.php
@@ -1,5 +1,5 @@
 <?php
-class Migration_insert_dashboard_page_meta_key extends Migration
+class Migration_insert_default_dashboard_meta_key extends Migration
 {
 
     public function up()

--- a/install/routes.php
+++ b/install/routes.php
@@ -95,7 +95,6 @@ Route::post('database', array('before' => 'check', 'main' => function () {
     try {
         $connection = DB::factory(array(
             'driver' => 'mysql',
-            'database' => $database['name'],
             'hostname' => $database['host'],
             'port' => $database['port'],
             'username' => $database['user'],
@@ -127,12 +126,10 @@ Route::get('metadata', array('before' => 'check', 'main' => function () {
         return Response::redirect('database');
     }
 
-    
-    $vars['site_path'] = dirname(dirname($_SERVER['SCRIPT_NAME']));
-    $vars['themes'] = Themes::all();
+    // windows users may return a \ so we replace it with a /
+    $vars['site_path'] = str_replace('\\','/', dirname(dirname($_SERVER['SCRIPT_NAME'])));
 
-    //  Fix for Windows screwing up directories
-    $vars['site_path'] = str_replace('\\', '/', $vars['site_path']);
+    $vars['themes'] = Themes::all();
 
     return Layout::create('metadata', $vars);
 }));
@@ -178,9 +175,7 @@ Route::get('account', array('before' => 'check', 'main' => function () {
         return Response::redirect('metadata');
     }
 
-    
-
-    return Layout::create('account', $vars);
+    return Layout::create('account', array());
 }));
 
 Route::post('account', array('before' => 'check', 'main' => function () {

--- a/install/run.php
+++ b/install/run.php
@@ -161,6 +161,11 @@ check('Anchor requires the php module <code>GD</code> to be installed.', functio
     return extension_loaded('gd');
 });
 
+// mb_strtolower() in anchor\helpers.php
+check('Anchor requires the php module <code>mbstring</code> to be installed.', function() {
+    return extension_loaded('mbstring');
+});
+
 if (count($GLOBALS['errors'])) {
     $vars['errors'] = $GLOBALS['errors'];
 

--- a/system/database/connectors/mysql.php
+++ b/system/database/connectors/mysql.php
@@ -49,7 +49,7 @@ class mysql extends Connector
         try {
             extract($config);
 
-            $dns = 'mysql:' . implode(';', array('dbname=' . $database, 'host=' . $hostname, 'port=' . $port, 'charset=' . $charset));
+            $dns = 'mysql:' . implode(';', isset($database) ? array('dbname=' . $database, 'host=' . $hostname, 'port=' . $port, 'charset=' . $charset) : array('host=' . $hostname, 'port=' . $port, 'charset=' . $charset));
             $this->pdo = new PDO($dns, $username, $password);
             $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $e) {


### PR DESCRIPTION
Attempt number 3 to commit to Anchor (#803, #1075)

- Anchor has an additional dependency on mbstring.
- Fixes the installation script failing if the database doesn't already
exist.
- Fixes the installation script failing if a full working database
already exists.
- Fixes a user being able to maliciously run the installation script to
overwrite a database.
- Fixes the URL not being escaped correctly when written into the PHP
script.
- The dirname() function on PHP for Windows can return strings
containing the \ character which will cause the installation to not
complete successfully if the user has not overridden it.
- Fix #1034.
- Fix #1035.