### PR TITLE
Partial fix for #961

### DIFF
--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -10,6 +10,13 @@ Options -indexes
 
 	# Rewrite all other URLs to index.php/URL
 	RewriteRule ^(.*)$ {{index}} [L]
+
+	# Rewrite anchor directories to index.php even though they exist.
+	RewriteRule ^(system.*)$ index.php/$1 [L]
+	RewriteRule ^(anchor.*)$ index.php/$1 [L]
+	RewriteRule ^(content.*)$ index.php/$1 [L]
+	RewriteRule ^(themes.*)$ index.php/$1 [L]
+	RewriteRule ^(vendor.*)$ index.php/$1 [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>

--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -16,11 +16,11 @@ Options -indexes
 	RewriteCond %{REQUEST_FILENAME} -f
 	RewriteRule .* - [S=5]
 
-	RewriteRule ^(system(?:$|\/.*$)) {{index}}[L]
-	RewriteRule ^(anchor(?:$|\/.*$)) {{index}}[L]
+	RewriteRule ^(system(?:$|\/.*$)) {{index}} [L]
+	RewriteRule ^(anchor(?:$|\/.*$)) {{index}} [L]
 	RewriteRule ^(content(?:$|\/.*$)) {{index}} [L]
-	RewriteRule ^(themes(?:$|\/.*$)) {{index}}[L]
-	RewriteRule ^(vendor(?:$|\/.*$)) {{index}}[L]
+	RewriteRule ^(themes(?:$|\/.*$)) {{index}} [L]
+	RewriteRule ^(vendor(?:$|\/.*$)) {{index}} [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>

--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -11,12 +11,16 @@ Options -indexes
 	# Rewrite all other URLs to index.php/URL
 	RewriteRule ^(.*)$ {{index}} [L]
 
-	# Rewrite anchor directories to index.php even though they exist.
-	RewriteRule ^(system.*)$ index.php/$1 [L]
-	RewriteRule ^(anchor.*)$ index.php/$1 [L]
-	RewriteRule ^(content.*)$ index.php/$1 [L]
-	RewriteRule ^(themes.*)$ index.php/$1 [L]
-	RewriteRule ^(vendor.*)$ index.php/$1 [L]
+	#Rewrite anchor directories to index.php/URL even though they exist.
+	#Don't rewrite files so that we can still load CSS, etc.
+	RewriteCond %{REQUEST_FILENAME} -f
+	RewriteRule .* - [S=5]
+
+	RewriteRule ^(system(?:$|\/.*$)) {{index}}[L]
+	RewriteRule ^(anchor(?:$|\/.*$)) {{index}}[L]
+	RewriteRule ^(content(?:$|\/.*$)) {{index}} [L]
+	RewriteRule ^(themes(?:$|\/.*$)) {{index}}[L]
+	RewriteRule ^(vendor(?:$|\/.*$)) {{index}}[L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>


### PR DESCRIPTION
### Partial fix for #961

This change to the .htaccess file will allow anchor directories to be processed by the CMS as though the directories did not exist. However, if the user creates a directory "something" and also creates a page whose slug is "something" the directory will be prefered over the page. 

I'm currently using a htaccess file modified according to the changes here on my site, I tried running a clean install of the master branch but ran into the problem in #1034, however the htaccess file was created correctly. 

### Changes proposed:

- Modified `install/storage/htaccess.distro` to allow pages with slugs equivalent to anchor directories to be correctly displayed. 