### PR TITLE
Fix for #1087 / Feature: Better search functionality

### DIFF
--- a/anchor/routes/site.php
+++ b/anchor/routes/site.php
@@ -238,15 +238,17 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
     $page->title = 'Search';
     $page->slug = 'search';
 
-    // get search term
-    $term = filter_var($slug, FILTER_SANITIZE_STRING);
-
-    // revert double-dashes back to spaces
-    $term = str_replace('--', ' ', $term);
-
     if ($offset <= 0) {
         return Response::create(new Template('404'), 404);
     }
+
+    // Convert custom escaped characters and escape MySQL special characters.
+    // http://stackoverflow.com/questions/712580/list-of-special-characters-for-sql-like-clause
+    $term = str_replace(
+                array('-sl-', '-bsl-', '-sp-', '%', '_'),
+                array('/', '\\\\', ' ', '\\%', '\\_'),
+                $slug
+            );
 
     // Posts, pages, or all
     if ($whatSearching === 'posts') {
@@ -261,9 +263,15 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
     }
 
     // search templating vars
+    $safeTerm = eq(str_replace(
+                    array('\\\\', '\\%', '\\_'),
+                    array('\\', '%', '_'),
+                    $term
+                ));
+
     Registry::set('page', $page);
     Registry::set('page_offset', $offset);
-    Registry::set('search_term', $term);
+    Registry::set('search_term', $safeTerm);
     Registry::set('search_results', new Items($results));
     Registry::set('total_posts', $total);
 
@@ -271,12 +279,16 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
 });
 
 Route::post('search', function () {
-    // Search term
-    $term = filter_var(Input::get('term', ''), FILTER_SANITIZE_STRING); // sanitize search term
-    $term = str_replace(' ', '--', $term); // replace spaces with double-dash to pass through url
+    // Search term, placeholders for / and \
+    $term = str_replace(
+                array('/', '\\', ' '),
+                array('-sl-', '-bsl-', '-sp-'),
+                Input::get('term', '')
+            );
+    $term = rawurlencode($term);
 
-    // What searching
-    $whatSearch = Input::get('whatSearch', ''); // get what we are searching for
+    // Get what we are searching for
+    $whatSearch = Input::get('whatSearch', '');
 
     // clamp the choices
     switch ($whatSearch) {
@@ -289,7 +301,7 @@ Route::post('search', function () {
             break;
     }
 
-    return Response::redirect('search/' . $whatSearch . '/' . slug($term));
+    return Response::redirect('search/' . $whatSearch . '/' . $term);
 });
 
 /**

--- a/anchor/routes/site.php
+++ b/anchor/routes/site.php
@@ -240,8 +240,6 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
 
     // get search term
     $term = filter_var($slug, FILTER_SANITIZE_STRING);
-    Session::put(slug($term), $term);
-    //$term = Session::get($slug); //this was for POST only searches
 
     // revert double-dashes back to spaces
     $term = str_replace('--', ' ', $term);
@@ -252,7 +250,7 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
 
     // Posts, pages, or all
     if ($whatSearching === 'posts') {
-        list($total, $results) = (Post::search($term, $offset, Post::perPage()));
+        list($total, $results) = Post::search($term, $offset, Post::perPage());
     } elseif ($whatSearching === 'pages') {
         list($total, $results) = Page::search($term, $offset);
     } else {
@@ -261,7 +259,7 @@ Route::get(array('search', 'search/(:any)', 'search/(:any)/(:any)', 'search/(:an
         $total = $postResults[0] + $pageResults[0];
         $results = array_merge($postResults[1], $pageResults[1]);
     }
-    
+
     // search templating vars
     Registry::set('page', $page);
     Registry::set('page_offset', $offset);
@@ -279,10 +277,17 @@ Route::post('search', function () {
 
     // What searching
     $whatSearch = Input::get('whatSearch', ''); // get what we are searching for
-    $whatSearch = $whatSearch === 'posts' ? 'posts' : $whatSearch === 'pages' ? 'pages' : 'all'; // clamp the choices
 
-    Session::put(slug($term), $term);
-    Session::put($whatSearch, $whatSearch);
+    // clamp the choices
+    switch ($whatSearch) {
+        case 'posts':
+            break;
+        case 'pages':
+            break;
+        default:
+            $whatSearch = 'all';
+            break;
+    }
 
     return Response::redirect('search/' . $whatSearch . '/' . slug($term));
 });

--- a/install/libraries/installer.php
+++ b/install/libraries/installer.php
@@ -151,7 +151,7 @@ class installer
         if (mod_rewrite() or (is_apache() and $settings['metadata']['rewrite'])) {
             $htaccess = Braces::compile(APP . 'storage/htaccess.distro', array(
                 'base' => $settings['metadata']['site_path'],
-                'index' => (is_cgi() ? 'index.php?/$1' : 'index.php/$1')
+                'index' => 'index.php?/$1'
             ));
 
             if (isset($htaccess) and is_writable($filepath = PATH)) {


### PR DESCRIPTION
### Fix for #1087

In an older version of Anchor, the Session was used to pass search terms between the function handling the post request and the function handling the get request to `search/all/(term)`. This, as of c60d201e1503e42bb67d82acbf5d59b5b79794e3 way back in 2013, was not used and simply not cleaned up. 

### Changes proposed:

- Removed unused session changes
- Refactored ternary statement for allowing set values in `$whatSearch` to a switch statement.

---

### Feature: Better search functionality

While fixing the above, I realized that searching for anything that wasn't alphanumeric (and spaces) would fail as the url was encoded through `slug()` rather than `rawurlencode()`. I also discovered that the search function allowed the use of % and _ as wildcards.

Also, searching for an empty string returns all posts, I have left this functionality untouched though it could be considered a bug. 

It also strikes me as strange that I can search for HTML tags as the search function checks `posts.html`. This is a bug for another day, especially as I believe it would be most easily solved by adding a `posts.text` field. (The `posts.html` field, run through `strip_tags()` and `urldecode()`)

### Changes proposed:

- Use `rawurlencode()` instead of `slug()` to allow non-alphanumeric characters when searching.
- Use `-sl-` and `-bsl-` as reasonably obscure search terms to manually encode slashes which would otherwise cause searches to fail.
- Use `-sp-` to encode spaces rather than `--` as it is less common (This shouldn't be necessary, but I can't seem to figure out what is eating the spaces)
- Escape % to \% and _ to \_, causing them to be used as literal characters rather than wildcards. [Ref.](http://stackoverflow.com/questions/712580/list-of-special-characters-for-sql-like-clause)
- Change `index` check in installation when creating htaccess file. Even if `is_cgi()` returns true, using `index.php/$1` results in 400 errors when searching for %. Thus, as `index.php?/$1` works correctly, it is now used exclusively. (Tested with XAMPP, it *may* be the case that I am missing something about this as I'm not sure why the test was used here in the first place).

### Test searches passed
- (empty string)
- %
- _
- 1
- mali\_cious
- mali\%cious
- test
- /[a-z]+/
- class="language-PHP"