### PR TITLE
Bug fixes and a few changes

### DIFF
--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -35,7 +35,7 @@ function slug($string, $separator = '-')
 function parse($str, $markdown = true)
 {
     // process tags
-    $pattern = '/[\{\{]{1}([a-z]+)[\}\}]{1}/i';
+    $pattern = '/{{([\w]+)}}/i';
 
     if (preg_match_all($pattern, $str, $matches)) {
         list($search, $replace) = $matches;
@@ -46,8 +46,6 @@ function parse($str, $markdown = true)
 
         $str = str_replace($search, $replace, $str);
     }
-
-    // $str = html_entity_decode($str, ENT_NOQUOTES, System\Config::app('encoding'));
 
     //  Parse Markdown as well?
     if ($markdown === true) {

--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -47,7 +47,7 @@ function parse($str, $markdown = true)
         $str = str_replace($search, $replace, $str);
     }
 
-    $str = html_entity_decode($str, ENT_NOQUOTES, System\Config::app('encoding'));
+    // $str = html_entity_decode($str, ENT_NOQUOTES, System\Config::app('encoding'));
 
     //  Parse Markdown as well?
     if ($markdown === true) {

--- a/anchor/language/en_GB/global.php
+++ b/anchor/language/en_GB/global.php
@@ -26,6 +26,7 @@ return array(
     'reset' => 'Reset',
     'all' => 'All',
     'cancel' => 'Cancel',
+    'preview' => 'Preview',
 
     // pagination
     'next' => 'Next',

--- a/anchor/libraries/anchor.php
+++ b/anchor/libraries/anchor.php
@@ -51,9 +51,9 @@ class anchor
         Config::set('meta', $meta);
     }
 
-    public static function functions()
+    public static function functions($force = false)
     {
-        if (! is_admin()) {
+        if (! is_admin() || $force) {
             $fi = new FilesystemIterator(APP . 'functions', FilesystemIterator::SKIP_DOTS);
 
             foreach ($fi as $file) {

--- a/anchor/libraries/uploader.php
+++ b/anchor/libraries/uploader.php
@@ -119,9 +119,9 @@ class uploader
     {
         $ext = pathinfo($filename, PATHINFO_EXTENSION);
 
-        $ext = strtolower($ext);
-
         $filename = basename($filename, '.' . $ext);
+
+        $ext = strtolower($ext);
 
         return $this->format_filename($filename) . '.' . $ext;
     }

--- a/anchor/libraries/validator.php
+++ b/anchor/libraries/validator.php
@@ -60,7 +60,7 @@ class validator
 
     public function check($key)
     {
-        $this->key = isset($this->payload[$key]) ? $key : null;
+        $this->key = array_key_exists($key, $this->payload) ? $key : null;
         $this->value = isset($this->payload[$this->key]) ? $this->payload[$this->key] : null;
 
         return $this;

--- a/anchor/migrations/212_insert_default_dashboard_meta_key.php
+++ b/anchor/migrations/212_insert_default_dashboard_meta_key.php
@@ -1,5 +1,5 @@
 <?php
-class Migration_insert_dashboard_page_meta_key extends Migration
+class Migration_insert_default_dashboard_meta_key extends Migration
 {
 
     public function up()

--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -43,15 +43,15 @@ class extend extends Base
         switch ($extend->field) {
             case 'text':
                 if (! empty($extend->value->text)) {
-                    $value = $extend->value->text;
+                    $value = eq($extend->value->text);
                 }
                 break;
 
             case 'html':
                 if (! empty($extend->value->html)) {
-                    $md = new Markdown;
+                    $md = new Parsedown();
 
-                    $value = $md->transform($extend->value->html);
+                    $value = $md->text($extend->value->html);
                 }
                 break;
 
@@ -186,8 +186,8 @@ class extend extends Base
         // not as files.
         $image_upload = Input::get('extend.' . $extend->key);
         if ($image_upload) {
-            $filename = basename($image_upload);
-            $name = $filename;
+            $filename = str_replace(Config::app('url') . '/content', '', $image_upload);
+            $name = basename($filename);
         }
 
         $data = compact('name', 'filename');

--- a/anchor/routes/fields.php
+++ b/anchor/routes/fields.php
@@ -6,7 +6,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         List Fields
     */
     Route::get(array('admin/extend/fields', 'admin/extend/fields/(:num)'), function ($page = 1) {
-        
+
         $vars['token'] = Csrf::token();
         $vars['extend'] = Extend::paginate($page, Config::get('admin.posts_per_page'));
 
@@ -19,7 +19,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Add Field
     */
     Route::get('admin/extend/fields/add', function () {
-        
+
         $vars['token'] = Csrf::token();
         $vars['types'] = Extend::$types;
 
@@ -34,25 +34,25 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
     Route::post('admin/extend/fields/add', function () {
         $input = Input::get(array('type', 'field', 'key', 'label', 'attributes', 'pagetype'));
-        
+
         if (empty($input['key'])) {
             $input['key'] = $input['label'];
         }
-        
+
         $input['key'] = slug($input['key'], '_');
-        
+
         // an array of items that we shouldn't encode - they're no XSS threat
         $dont_encode = array('attributes');
-        
+
         foreach ($input as $key => &$value) {
             if (in_array($key, $dont_encode)) {
                 continue;
             }
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
-        
+
         $validator->add('valid_key', function ($str) use ($input) {
             return Extend::where('key', '=', $str)
                 ->where('type', '=', $input['type'])->count() == 0;
@@ -103,7 +103,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Edit Field
     */
     Route::get('admin/extend/fields/edit/(:num)', function ($id) {
-        
+
         $vars['token'] = Csrf::token();
         $vars['types'] = Extend::$types;
         $vars['fields'] = Extend::$field_types;
@@ -125,19 +125,19 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
     Route::post('admin/extend/fields/edit/(:num)', function ($id) {
         $input = Input::get(array('type', 'field', 'key', 'label', 'attributes', 'pagetype'));
-        
+
         if (empty($input['key'])) {
             $input['key'] = $input['label'];
         }
-        
+
         $input['key'] = slug($input['key'], '_');
-        
-        foreach ($input as $key => &$value) {
+
+        array_walk_recursive($input, function(&$value) {
             $value = eq($value);
-        }
-        
+        });
+
         $validator = new Validator($input);
-        
+
         $validator->add('valid_key', function ($str) use ($id, $input) {
             return Extend::where('key', '=', $str)
                 ->where('type', '=', $input['type'])

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -13,7 +13,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         $pagination = new Paginator($posts, $total, $page, $perpage, $url);
 
-        
+
         $vars['posts'] = $pagination;
         $vars['categories'] = Category::sort('title')->get();
         $vars['status'] = 'all';
@@ -68,7 +68,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         $pagination = new Paginator($posts, $total, $post, $perpage, $url);
 
-        
+
         $vars['posts'] = $pagination;
         $vars['status'] = $status;
         $vars['categories'] = Category::sort('title')->get();
@@ -83,7 +83,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Edit post
     */
     Route::get('admin/posts/edit/(:num)', function ($id) {
-        
+
         $vars['token'] = Csrf::token();
         $vars['article'] = Post::find($id);
         $vars['page'] = Registry::get('posts_page');
@@ -116,17 +116,17 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         // convert to ascii
         $input['slug'] = slug($input['slug']);
-        
+
         // an array of items that we shouldn't encode - they're no XSS threat
         $dont_encode = array('description', 'markdown', 'css', 'js');
-        
+
         foreach ($input as $key => &$value) {
             if (in_array($key, $dont_encode)) {
                 continue;
             }
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
 
         $validator->add('duplicate', function ($str) use ($id) {
@@ -188,7 +188,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Add new post
     */
     Route::get('admin/posts/add', function () {
-        
+
         $vars['token'] = Csrf::token();
         $vars['page'] = Registry::get('posts_page');
 
@@ -220,17 +220,17 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         // convert to ascii
         $input['slug'] = slug($input['slug']);
-        
+
         // an array of items that we shouldn't encode - they're no XSS threat
         $dont_encode = array('description', 'markdown', 'css', 'js');
-        
+
         foreach ($input as $key => &$value) {
             if (in_array($key, $dont_encode)) {
                 continue;
             }
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
 
         $validator->add('duplicate', function ($str) {
@@ -299,14 +299,23 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
     /*
         Preview post
     */
-    Route::post('admin/posts/preview', function () {
-        $markdown = Input::get('markdown');
+    Route::get('admin/posts/preview/(:num)', function ($postId) {
+        //Load functions, even though this is an admin page.
+        Anchor::functions(true);
 
-        // apply markdown processing
-        $md = new Markdown;
-        $output = Json::encode(array('markdown' => $md->transform($markdown)));
+        $posts_page = Registry::get('posts_page');
 
-        return Response::create($output, 200, array('content-type' => 'application/json'));
+        if (!$post = Post::id($postId)) {
+            return Response::create(new Template('404'), 404);
+        }
+
+        $post->title .= ' (' . __('global.preview') . ')';
+
+        Registry::set('page', $posts_page);
+        Registry::set('article', $post);
+        Registry::set('category', Category::find($post->category));
+
+        return new Template('article');
     });
 
     /*

--- a/anchor/routes/variables.php
+++ b/anchor/routes/variables.php
@@ -6,7 +6,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         List Vars
     */
     Route::get('admin/extend/variables', function () {
-        
+
         $vars['token'] = Csrf::token();
 
         $variables = array();
@@ -28,7 +28,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Add Var
     */
     Route::get('admin/extend/variables/add', function () {
-        
+
         $vars['token'] = Csrf::token();
 
         return View::create('extend/variables/add', $vars)
@@ -38,15 +38,15 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
     Route::post('admin/extend/variables/add', function () {
         $input = Input::get(array('key', 'value'));
-        
+
         $input['key'] = 'custom_' . slug($input['key'], '_');
-        
+
         foreach ($input as $key => &$value) {
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
-        
+
         $validator->add('valid_key', function ($str) {
             return Query::table(Base::table('meta'))
                 ->where('key', '=', $str)
@@ -77,7 +77,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Edit Var
     */
     Route::get('admin/extend/variables/edit/(:any)', function ($key) {
-        
+
         $vars['token'] = Csrf::token();
         $vars['variable'] = Query::table(Base::table('meta'))->where('key', '=', $key)->fetch();
 
@@ -91,23 +91,23 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
     Route::post('admin/extend/variables/edit/(:any)', function ($key) {
         $input = Input::get(array('key', 'value'));
-        
+
         $input['key'] = 'custom_' . slug($input['key'], '_');
-        
-        foreach ($input as $key => &$value) {
+
+        foreach ($input as &$value) {
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
-        
+
         $validator->add('valid_key', function ($str) use ($key) {
-            // no change
+            // no change in key
             if ($str == $key) {
-                return false;
+                return true;
             }
 
             // check the new key $str is available
-            return Query::table(Base::table('meta'))->where('key', '=', $str)->count() != 0;
+            return Query::table(Base::table('meta'))->where('key', '=', $str)->count() == 0;
         });
 
         $validator->check('key')

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -6,7 +6,7 @@
 
 	<fieldset class="header">
 		<div class="wrap">
-			
+
 
 			<?php echo Form::text('title', Input::previous('title', $article->title), array(
                 'placeholder' => __('posts.title'),
@@ -19,7 +19,12 @@
                     'type' => 'submit',
                     'class' => 'btn'
                 )); ?>
-				
+
+				<?php echo Html::link('admin/posts/preview/' . $article->id, __('global.preview'), array(
+					'class' => 'btn blue',
+					'target' => '_blank'
+				)); ?>
+
 				<?php echo Html::link('admin/posts', __('global.cancel'), array(
                     'class' => 'btn cancel blue'
                 )); ?>

--- a/install/routes.php
+++ b/install/routes.php
@@ -11,7 +11,7 @@ Route::action('check', function () {
     Start (Language Select)
 */
 Route::get(array('/', 'start'), array('before' => 'check', 'main' => function () {
-    
+
 
     $vars['languages'] = languages();
     $vars['prefered_languages'] = prefered_languages();
@@ -57,7 +57,7 @@ Route::get('database', array('before' => 'check', 'main' => function () {
         return Response::redirect('start');
     }
 
-    
+
     $vars['collations'] = array(
         'utf8_bin' => 'Unicode (multilingual), Binary',
         'utf8_czech_ci' => 'Czech, case-insensitive',
@@ -103,7 +103,7 @@ Route::post('database', array('before' => 'check', 'main' => function () {
             'charset' => 'utf8',
             'prefix' => $database['prefix']
         ));
-    } catch (PDOException $e) {
+    } catch (Exception $e) {
         Input::flash();
 
         Notify::error($e->getMessage());
@@ -127,7 +127,7 @@ Route::get('metadata', array('before' => 'check', 'main' => function () {
         return Response::redirect('database');
     }
 
-    
+
     $vars['site_path'] = dirname(dirname($_SERVER['SCRIPT_NAME']));
     $vars['themes'] = Themes::all();
 

--- a/install/views/account.php
+++ b/install/views/account.php
@@ -6,10 +6,12 @@
 		<h1>Your first account</h1>
 
 		<p>Oh, we're so tantalisingly close! All we need now is a username and password to log in to the admin area with.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo uri_to('account'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/complete.php
+++ b/install/views/complete.php
@@ -1,5 +1,7 @@
 <?php echo $header; ?>
 
+<?php echo Notify::read(); ?>
+
 <section class="content small">
 	<h1>Install complete!</h1>
 

--- a/install/views/database.php
+++ b/install/views/database.php
@@ -5,10 +5,11 @@
 		<h1>Your database details</h1>
 
 		<p>Firstly, we’ll need a database. Anchor needs them to store all of your blog’s information, so it’s vital you fill these in correctly. If you don’t know what these are, you’ll need to contact your webhost.</p>
-	</article>
 
+		<?php echo Notify::read(); ?>
+	</article>
 	<form method="post" action="<?php echo uri_to('database'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/metadata.php
+++ b/install/views/metadata.php
@@ -5,10 +5,12 @@
 		<h1>Site metadata</h1>
 
 		<p>In order to personalise your Anchor blog, it's recommended you add some metadata about your site. This can all be changed at any time, though.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo Uri::to('metadata'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/start.php
+++ b/install/views/start.php
@@ -7,10 +7,12 @@
 		<p>If you were looking for a truly lightweight blogging experience, you&rsquo;ve
 		found the right place. Simply fill in the details below, and you&rsquo;ll have your
 		new blog set up in no time.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo uri_to('start'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/system/input.php
+++ b/system/input.php
@@ -56,13 +56,7 @@ class input
             return static::get_array($key, $fallback);
         }
 
-        $data = Arr::get(static::$array, $key, $fallback);
-
-        if (is_string($data)) {
-            return e($data);
-        }
-
-        return $data;
+        return Arr::get(static::$array, $key, $fallback);
     }
 
     /**

--- a/themes/default/article.php
+++ b/themes/default/article.php
@@ -3,7 +3,7 @@
 			<h1><?php echo article_title(); ?></h1>
 
 			<article>
-				<?php echo article_markdown(); ?>
+				<?php echo article_html(); ?>
 			</article>
 
 			<section class="footnote">


### PR DESCRIPTION
I did my best to format this to be easily reviewed... Sorry, it got really long. Mostly in chronological order. I also added a commit section as several commits included fixes for multiple issues. 

### Fix for #1089 (Incorrect timezone for Dhaka)
`DateTimeZone::listAbbreviations` returns an incorrect list of timezone offsets because of historical reasons, it can still be used, however, if the list is iterated over and each timezone is calculated based on the time the script was run. [Credit is due to Jonathan on SO](http://stackoverflow.com/questions/1727077/generating-a-drop-down-list-of-timezones-with-php/21211073#21211073)

### Commits
- 738336f28419d954c87ac4ac8aa31dc81d560dd9

### Changes proposed:

- Refactored `timezones()` function to display correct offsets.

---

### Fix for #1034 (Migration issue)

There is already a pull request for this, but I needed to fix it to run the master repo on my machine so I used [elenachoi's solution](https://github.com/anchorcms/anchor-cms/issues/1034#issuecomment-207893147). 

### Commits
- a1b8b4b3c261952f7c5da1d72415f7cbf2c03fb0 

### Changes proposed

- Rename class `Migration_insert_dashboard_page_meta_key ` to `Migration_insert_default_dashboard_meta_key`

---


### Fix for #1046 (Custom JS is being escaped)

The cause of this bug was bc202b52e08cd48c5cea0508c83bd40fb588a645, as everything was encoded when first fetched, nearly every input was encoded twice, and the JS was encoded. The fix was to remove this, and also check everywhere `Input::get()` was used to ensure that encoding wasn't missed (nowhere...).

### Commits

- 40cf83eefbb9d659e54fbe7b7a4d43e47e2af00b
- b761f244bfeb69f09199fa055a5ff6bfe6c886df

### Changes proposed
- Revert bc202b52e08cd48c5cea0508c83bd40fb588a645, which encoded all input
- Remove decoding of input when updating post as it is no longer needed. 

---

### Display article HTML rather than article markdown
`article_markdown` used to be used in themes instead of `article_html` to display the markdown, however, due to 8c3ef08d681b55da553b9f04a30085bd4a16d125, `article_markdown` no longer correctly displayed the HTML. Rather than reverting that change, which I believe is good as it makes the function return what it sounds like it should return, I changed the theme to use `article_html`. 

### Commits
- fed237ed457506d52d434e0153f84def0bab7cc7

### Changes proposed
- Use `article_html` instead of `article_markdown` when displaying articles. 

---

### Add previewing posts functionality
I noticed the route in the `anchor/routes/posts.php` file which attempted to create a page which would return the translated markdown for previewing posts. As this would not display the markdown in the context of the used theme, I refactored this to be a preview page using the current theme and currently saved HTML. 

### Commits
- 76f6d7431e03b0de11b82b533cbb20867e3f2d5c

### Changes proposed
- Create `Route::get('admin/posts/preview/(:num)'` to allow previewing the current post.
- Remove broken `Route::post('admin/posts/preview'`. 
- Add `preview` to the language files for a preview button next to the save button at the top of posts.
- Add optional `$force` parameter to `Anchor::functions` to allow the preview to work in an admin route.

---

### Fix #1097 (path in images dropped on post) / Refactor uploading files

Before this, all files were uploaded to `content/`, which could lead to thousands of files in a single directory. Now, new files are stored in `content/yyyy/mm/`. Also, if a file with the same name was uploaded more than once, it would overwrite the original. Apparently I'm [not the only one](http://forums.anchorcms.com/general/adding-pictures-filenames) to run into this problem. In the process of doing this, I also fixed #1097.

### Commits
- 3fbe5d0772e4575450f2e98e9b8cb66f95157db4
- 27aa9cfa7288163abed60688eda4ac165db59d23

### Changes proposed
- Upload new files to `content/yyyy/mm/` instead of `content/`. 
- Files with identical names should be transparently renamed, instead of replacing the original. 
- Fix path when dragging an image onto posts (#1097)
- Fix upload script, `Test.PNG` should be uploaded as `Test.png`, not `Test-PNG.png`


---

### Fix #1086 (HTML page field)
This was easy... The field simply used the `Markdown` class which isn't used by Anchor. Changing it to `Parsedown` fixed the issue. I also added input filtering for Text fields as the assumption for their use is outputting text rather than HTML. 

### Commits
- 27aa9cfa7288163abed60688eda4ac165db59d23

### Changes proposed
- Add output filtering for text fields
- Use `Parsedown` instead of `Markdown` class. 
- Change filename for files to support directories with yyyy/mm (also mentioned above)

---

### Fix #1096 (Database connection details visible...)
Simple fix, changing the catch statement to catch all `Exception`s rather than just `PDOException`s allowed all exceptions to be caught and the installer to be notified without an error page. 

### Commits
- 8240ebdb3a118bb06706f57dadf76956526ec150

### Changes proposed
- Fix validator bug where if the value was null, checks would always pass (ran into this while making the installer break) 
- Catch `Exception` rather than `PDOException` to avoid showing database info if the connection fails
- Add `Notify::Read` to all install views so that the installer can be notified about what went wrong. 

---

### Fix #1068 (fields edit bug)
If an image or file is uploaded as a custom field to a post, and the post is saved, it would produce an error as the script assumed that every input in `$input` was a string. 

### Commits
- 9942a8d442b3ca9cb2f05180c25c821537374582

### Changes proposed
- Use `array_walk_recursive` instead of foreach to run the values through `eq()`

---

### Fix updating site variables / Fix matching site variables in posts
Whenever updating a site variable, I would be notified that it was successfully updated, but it would fail to update. Also, most tags failed to be parsed as the regex did not accept underscores. 

### Commits
- 3141c83a962b5a7a9614947acabcb8867969edc2

### Changes proposed
- Change regex to allow alphanumeric characters and underscores, and also to only check tags within {{}} instead of {}
- Fix edit function to correctly check if the key used was valid. 