### PR TITLE
Fix #1096 (Database connection details visible...)

### DIFF
--- a/anchor/libraries/validator.php
+++ b/anchor/libraries/validator.php
@@ -60,7 +60,7 @@ class validator
 
     public function check($key)
     {
-        $this->key = isset($this->payload[$key]) ? $key : null;
+        $this->key = array_key_exists($key, $this->payload) ? $key : null;
         $this->value = isset($this->payload[$this->key]) ? $this->payload[$this->key] : null;
 
         return $this;

--- a/install/routes.php
+++ b/install/routes.php
@@ -11,7 +11,7 @@ Route::action('check', function () {
     Start (Language Select)
 */
 Route::get(array('/', 'start'), array('before' => 'check', 'main' => function () {
-    
+
 
     $vars['languages'] = languages();
     $vars['prefered_languages'] = prefered_languages();
@@ -57,7 +57,7 @@ Route::get('database', array('before' => 'check', 'main' => function () {
         return Response::redirect('start');
     }
 
-    
+
     $vars['collations'] = array(
         'utf8_bin' => 'Unicode (multilingual), Binary',
         'utf8_czech_ci' => 'Czech, case-insensitive',
@@ -103,7 +103,7 @@ Route::post('database', array('before' => 'check', 'main' => function () {
             'charset' => 'utf8',
             'prefix' => $database['prefix']
         ));
-    } catch (PDOException $e) {
+    } catch (Exception $e) {
         Input::flash();
 
         Notify::error($e->getMessage());
@@ -127,7 +127,7 @@ Route::get('metadata', array('before' => 'check', 'main' => function () {
         return Response::redirect('database');
     }
 
-    
+
     $vars['site_path'] = dirname(dirname($_SERVER['SCRIPT_NAME']));
     $vars['themes'] = Themes::all();
 

--- a/install/views/account.php
+++ b/install/views/account.php
@@ -6,10 +6,12 @@
 		<h1>Your first account</h1>
 
 		<p>Oh, we're so tantalisingly close! All we need now is a username and password to log in to the admin area with.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo uri_to('account'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/complete.php
+++ b/install/views/complete.php
@@ -1,5 +1,7 @@
 <?php echo $header; ?>
 
+<?php echo Notify::read(); ?>
+
 <section class="content small">
 	<h1>Install complete!</h1>
 

--- a/install/views/database.php
+++ b/install/views/database.php
@@ -5,10 +5,12 @@
 		<h1>Your database details</h1>
 
 		<p>Firstly, we’ll need a database. Anchor needs them to store all of your blog’s information, so it’s vital you fill these in correctly. If you don’t know what these are, you’ll need to contact your webhost.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo uri_to('database'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/metadata.php
+++ b/install/views/metadata.php
@@ -5,10 +5,12 @@
 		<h1>Site metadata</h1>
 
 		<p>In order to personalise your Anchor blog, it's recommended you add some metadata about your site. This can all be changed at any time, though.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo Uri::to('metadata'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>

--- a/install/views/start.php
+++ b/install/views/start.php
@@ -7,10 +7,12 @@
 		<p>If you were looking for a truly lightweight blogging experience, you&rsquo;ve
 		found the right place. Simply fill in the details below, and you&rsquo;ll have your
 		new blog set up in no time.</p>
+
+		<?php echo Notify::read(); ?>
 	</article>
 
 	<form method="post" action="<?php echo uri_to('start'); ?>" autocomplete="off">
-		
+
 
 		<fieldset>
 			<p>


### PR DESCRIPTION
### Fix #1096 (Database connection details visible...)
Simple fix, changing the catch statement to catch all `Exception`s rather than just `PDOException`s allowed all exceptions to be caught and the installer to be notified without an error page. 

### Changes proposed
- Fix validator bug where if the value was null, checks would always pass (ran into this while making the installer break) 
- Catch `Exception` rather than `PDOException` to avoid showing database info if the connection fails
- Add `Notify::Read` to all install views so that the user can be notified about what went wrong. 
