### PR TITLE
Fix for #1089 (Incorrect timezone for Dhaka)

### DIFF
--- a/install/run.php
+++ b/install/run.php
@@ -39,38 +39,26 @@ if ($route = Arr::get($_GET, 'route', '/')) {
 */
 function timezones()
 {
-    $list = DateTimeZone::listIdentifiers();
-    $data = array();
-    foreach ($list as $id => $zone) {
-        $date= new DateTime(null, new DateTimeZone($zone));
-        $ds = $date->format('I');
-        $offset = $date->getOffset();
-        $gmt = round(abs($offset / 3600), 2);
-        $gmt = ($ds == 1 ? $gmt : $gmt-1);
-        $minutes = fmod($gmt, 1);
-        if ($minutes == 0) {
-            $offset_label = $gmt.'&nbsp;&nbsp;';
-        } elseif ($minutes == 0.5) {
-            $offset_label = (int)$gmt.'.30';
-        } elseif ($minutes == 0.75) {
-            $offset_label = (int)$gmt.'.45';
-        }
-        $sign = $offset > 0 ? '+' : '-';
-        if ($offset == 0) {
-            $sign = ' ';
-            $offset = '';
-        }
-        $label = 'GMT' . $sign . $offset_label . '&nbsp;'  . $zone;
-        $data[$offset][$zone] = array('offset'=> $offset, 'label' => $label, 'timezone_id' => $zone);
-    }
-    ksort($data);
     $timezones = array();
-    foreach ($data as $offsets) {
-        ksort($offsets);
-        foreach ($offsets as $zone) {
-            $timezones[] = $zone;
+    $now = new DateTime('now', new DateTimeZone('UTC'));
+    foreach (DateTimeZone::listIdentifiers() as $timezone) {
+        $now->setTimezone(new DateTimeZone($timezone));
+        $offset = $now->getOffset();
+        $hours = intval($offset / 3600);
+        $minutes = abs(intval($offset % 3600 / 60));
+        //Create the label
+        $label = 'GMT';
+        if ($offset) {
+            $label .= ($hours < 0 ? '' : '+') . $hours;
+            $label .= $minutes ? '.' . $minutes : '&nbsp;&nbsp;';
         }
+        $label .= '&nbsp;' . $timezone;
+        $timezones[] = array('offset' => $offset, 'timezone_id' => $timezone, 'label' => $label);
     }
+    //Sort by offset, and then by timezone_id.
+    usort($timezones, function($a, $b) {
+        return ($a['offset'] - $b['offset']) - strcmp($b['timezone_id'], $a['timezone_id']);
+    });
     return $timezones;
 }
 


### PR DESCRIPTION
### Fix for #1089 (Incorrect timezone for Dhaka)

`DateTimeZone::listAbbreviations` returns an incorrect list of timezone offsets because of historical reasons. It can still be used, however, if the list is iterated over and each timezone is calculated based on the time the script was run. [Credit is due to Jonathan on SO](http://stackoverflow.com/questions/1727077/generating-a-drop-down-list-of-timezones-with-php/21211073#21211073)

### Changes proposed:

- Refactored `timezones()` function to display correct offsets.