### PR TITLE
Fix for #1046 (Custom JS is being escaped)

### DIFF
--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -47,8 +47,6 @@ function parse($str, $markdown = true)
         $str = str_replace($search, $replace, $str);
     }
 
-    $str = html_entity_decode($str, ENT_NOQUOTES, System\Config::app('encoding'));
-
     //  Parse Markdown as well?
     if ($markdown === true) {
         $md = new Parsedown;

--- a/system/input.php
+++ b/system/input.php
@@ -56,13 +56,7 @@ class input
             return static::get_array($key, $fallback);
         }
 
-        $data = Arr::get(static::$array, $key, $fallback);
-
-        if (is_string($data)) {
-            return e($data);
-        }
-
-        return $data;
+        return Arr::get(static::$array, $key, $fallback);
     }
 
     /**


### PR DESCRIPTION
### Fix for #1046 (Custom JS is being escaped)

The cause of this bug was bc202b52e08cd48c5cea0508c83bd40fb588a645, as everything was encoded when first fetched, nearly every input was encoded twice, and the JS was encoded. The fix was to remove this, and also check everywhere `Input::get()` was used to ensure that encoding wasn't missed (nowhere...).
### Changes proposed
- Revert bc202b52e08cd48c5cea0508c83bd40fb588a645, which encoded all input
- Remove decoding of input when updating post as it is no longer needed. 
