### PR TITLE
Fix: Articles should display html, not markdown

### DIFF
--- a/themes/default/article.php
+++ b/themes/default/article.php
@@ -3,7 +3,7 @@
 			<h1><?php echo article_title(); ?></h1>
 
 			<article>
-				<?php echo article_markdown(); ?>
+				<?php echo article_html(); ?>
 			</article>
 
 			<section class="footnote">


### PR DESCRIPTION
### Display article HTML rather than article markdown
`article_markdown` used to be used in themes instead of `article_html` to display the markdown, however, due to 8c3ef08d681b55da553b9f04a30085bd4a16d125, `article_markdown` no longer correctly displayed the HTML. Rather than reverting that change, which I believe is good as it makes the function return what it sounds like it should return, I changed the theme to use `article_html`. 

### Changes proposed
- Use `article_html` instead of `article_markdown` when displaying articles. 
