### PR TITLE
Add previewing posts functionality

### DIFF
--- a/anchor/language/en_GB/global.php
+++ b/anchor/language/en_GB/global.php
@@ -26,6 +26,7 @@ return array(
     'reset' => 'Reset',
     'all' => 'All',
     'cancel' => 'Cancel',
+    'preview' => 'Preview',
 
     // pagination
     'next' => 'Next',

--- a/anchor/libraries/anchor.php
+++ b/anchor/libraries/anchor.php
@@ -51,9 +51,9 @@ class anchor
         Config::set('meta', $meta);
     }
 
-    public static function functions()
+    public static function functions($force = false)
     {
-        if (! is_admin()) {
+        if (! is_admin() || $force) {
             $fi = new FilesystemIterator(APP . 'functions', FilesystemIterator::SKIP_DOTS);
 
             foreach ($fi as $file) {

--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -13,7 +13,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         $pagination = new Paginator($posts, $total, $page, $perpage, $url);
 
-        
+
         $vars['posts'] = $pagination;
         $vars['categories'] = Category::sort('title')->get();
         $vars['status'] = 'all';
@@ -68,7 +68,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         $pagination = new Paginator($posts, $total, $post, $perpage, $url);
 
-        
+
         $vars['posts'] = $pagination;
         $vars['status'] = $status;
         $vars['categories'] = Category::sort('title')->get();
@@ -83,7 +83,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Edit post
     */
     Route::get('admin/posts/edit/(:num)', function ($id) {
-        
+
         $vars['token'] = Csrf::token();
         $vars['article'] = Post::find($id);
         $vars['page'] = Registry::get('posts_page');
@@ -116,17 +116,17 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         // convert to ascii
         $input['slug'] = slug($input['slug']);
-        
+
         // an array of items that we shouldn't encode - they're no XSS threat
         $dont_encode = array('description', 'markdown', 'css', 'js');
-        
+
         foreach ($input as $key => &$value) {
             if (in_array($key, $dont_encode)) {
                 continue;
             }
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
 
         $validator->add('duplicate', function ($str) use ($id) {
@@ -188,7 +188,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         Add new post
     */
     Route::get('admin/posts/add', function () {
-        
+
         $vars['token'] = Csrf::token();
         $vars['page'] = Registry::get('posts_page');
 
@@ -220,17 +220,17 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
 
         // convert to ascii
         $input['slug'] = slug($input['slug']);
-        
+
         // an array of items that we shouldn't encode - they're no XSS threat
         $dont_encode = array('description', 'markdown', 'css', 'js');
-        
+
         foreach ($input as $key => &$value) {
             if (in_array($key, $dont_encode)) {
                 continue;
             }
             $value = eq($value);
         }
-        
+
         $validator = new Validator($input);
 
         $validator->add('duplicate', function ($str) {
@@ -299,14 +299,21 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
     /*
         Preview post
     */
-    Route::post('admin/posts/preview', function () {
-        $markdown = Input::get('markdown');
+    Route::get('admin/posts/preview/(:num)', function ($postId) {
+        //Load functions, even though this is an admin page.
+        Anchor::functions(true);
+        
+        $posts_page = Registry::get('posts_page');
+        if (!$post = Post::id($postId)) {
+            return Response::create(new Template('404'), 404);
+        }
 
-        // apply markdown processing
-        $md = new Markdown;
-        $output = Json::encode(array('markdown' => $md->transform($markdown)));
+        $post->title .= ' (' . __('global.preview') . ')';
 
-        return Response::create($output, 200, array('content-type' => 'application/json'));
+        Registry::set('page', $posts_page);
+        Registry::set('article', $post);
+        Registry::set('category', Category::find($post->category));
+        return new Template('article');
     });
 
     /*

--- a/anchor/views/posts/edit.php
+++ b/anchor/views/posts/edit.php
@@ -6,7 +6,7 @@
 
 	<fieldset class="header">
 		<div class="wrap">
-			
+
 
 			<?php echo Form::text('title', Input::previous('title', $article->title), array(
                 'placeholder' => __('posts.title'),
@@ -19,7 +19,12 @@
                     'type' => 'submit',
                     'class' => 'btn'
                 )); ?>
-				
+
+				<?php echo Html::link('admin/posts/preview/' . $article->id, __('global.preview'), array(
+					'class' => 'btn blue',
+					'target' => '_blank'
+				)); ?>
+
 				<?php echo Html::link('admin/posts', __('global.cancel'), array(
                     'class' => 'btn cancel blue'
                 )); ?>


### PR DESCRIPTION
### Add previewing posts functionality
I noticed the route in the `anchor/routes/posts.php` file which attempted to create a page which would return the translated markdown for previewing posts. As this would not display the markdown in the context of the used theme, I refactored this to be a preview page using the current theme and currently saved HTML. 

### Changes proposed
- Create `Route::get('admin/posts/preview/(:num)'` to allow previewing the current post.
- Remove broken `Route::post('admin/posts/preview'`. 
- Add `preview` to the language files for a preview button next to the save button at the top of posts.
- Add optional `$force` parameter to `Anchor::functions` to allow the preview to work in an admin route.
