### PR TITLE
Fixing a better metadata view for the default theme

### DIFF
--- a/anchor/functions/pages.php
+++ b/anchor/functions/pages.php
@@ -66,6 +66,18 @@ function page_status($page_item = null)
     return ($page_item ? $page_item->status : Registry::prop('page', 'status'));
 }
 
+
+function page_description($default = '') 
+{
+	if ($title = Registry::prop('article', 'description')) {
+		return $title;
+	}
+	if ($title = Registry::prop('site', 'description')) {
+		return $title;
+	}
+	return $default;
+}
+
 function page_custom_field($key, $default = '', $id = null)
 {
     if ($id == null) {

--- a/themes/default/header.php
+++ b/themes/default/header.php
@@ -24,12 +24,12 @@
 	    <meta name="viewport" content="width=device-width">
 	    <meta name="generator" content="Anchor CMS">
 
-	    <meta property="og:title" content="<?php echo site_name(); ?>">
+	    <meta property="og:title" content="<?php echo page_name(); ?>">
 	    <meta property="og:type" content="website">
 	    <meta property="og:url" content="<?php echo e(current_url()); ?>">
 	    <meta property="og:image" content="<?php echo theme_url('img/og_image.gif'); ?>">
 	    <meta property="og:site_name" content="<?php echo site_name(); ?>">
-	    <meta property="og:description" content="<?php echo site_description(); ?>">
+	    <meta property="og:description" content="<?php echo page_description(); ?>">
 
 		<?php if (customised()): ?>
 		    <!-- Custom CSS -->


### PR DESCRIPTION
I added a function called page_description to select either post_description or site_description.
Made changes to the headers file in default theme so page_description is being used there. 
Plus enabled the function for selecting page_title in same file.
