### PR TITLE
C'mon! Atleast try compose our dependencies!

### DIFF
--- a/anchor/composer_check.php
+++ b/anchor/composer_check.php
@@ -2,5 +2,9 @@
 
 // If that didn't work then produce an error
 if (!file_exists(PATH . 'vendor')) {
-    die('<code>We were unable to run composer our selves. Please run "composer install" from the command line to install Anchor. If you do not have composer installed please see <a href="https://getcomposer.org/">https://getcomposer.org/</a></code>');
+    $completeGud = 0;
+    $out = array();
+    $cmd = "composer install";
+    exec("$cmd 2>&1", $out, $completeGud); // 2>&1 so STDERR also goes to STDOUT.
+    if($completeGud !== 0) die('<code>We were unable to run composer our selves. Please run "composer install" from the command line to install Anchor. If you do not have composer installed please see <a href="https://getcomposer.org/">https://getcomposer.org/</a><br>(Error #' . $completeGud . ') Here is the output of the command:<br>' . implode("<br>", $out) . '</code>');
 }


### PR DESCRIPTION
### Fix for #1115

Fixes and makes Anchor `composer install` as well as report any issues as required.

### Changes proposed:

- Altered `composer_check.php` to have Anchor install dependencies.

Anchor now should attempt to `composer install`. Anchor will also report on any errors.