### PR TITLE
Mistakes were made in #1113. Metadata has correct info now.

### DIFF
--- a/anchor/functions/pages.php
+++ b/anchor/functions/pages.php
@@ -72,7 +72,7 @@ function page_description($default = '')
 	if ($title = Registry::prop('article', 'description')) {
 		return $title;
 	}
-	if ($title = Registry::prop('site', 'description')) {
+	if ($title = Config::meta('description')) {
 		return $title;
 	}
 	return $default;

--- a/themes/default/header.php
+++ b/themes/default/header.php
@@ -24,7 +24,7 @@
 	    <meta name="viewport" content="width=device-width">
 	    <meta name="generator" content="Anchor CMS">
 
-	    <meta property="og:title" content="<?php echo page_name(); ?>">
+	    <meta property="og:title" content="<?php echo page_title(); ?>">
 	    <meta property="og:type" content="website">
 	    <meta property="og:url" content="<?php echo e(current_url()); ?>">
 	    <meta property="og:image" content="<?php echo theme_url('img/og_image.gif'); ?>">


### PR DESCRIPTION
### Actually makes changes work as promised in #1113

I said that #1113 would improve metadata views but I mistakenly removed the main site description and set the wrong title. 
- Changed the default theme to use page_title for meta in og:title
- Made it so that page_description points to site description if no article is being viewed.


### Changes proposed:
- Add a description field for pages so that metadata is further customizable and can be more relevant. (site_description for main page <- page_description for pages <- article_description for posts)
