### PR TITLE
get the full article URL with article_full_url()

### DIFF
--- a/anchor/functions/articles.php
+++ b/anchor/functions/articles.php
@@ -63,7 +63,7 @@ function article_next_url($draft = false, $archive = false)
 }
 
 /**
- * Get the url of the current article
+ * Get the relative url of the current article
  * @return string
  */
 function article_url()
@@ -71,6 +71,16 @@ function article_url()
     $page = Registry::get('posts_page');
 
     return base_url($page->slug . '/' . article_slug());
+}
+
+/**
+ * Get the full url of the current article
+ * @return string
+ */
+function article_full_url() {
+	$page = Registry::get('posts_page');
+
+	return full_url($page->slug . '/' . article_slug());
 }
 
 /**


### PR DESCRIPTION
### Feature

Get an article's full URL with article_full_url().

### Changes proposed:

- Add article_full_url() to functions/articles.php

- This is useful for implementing "share this" buttons, or for adding open graph meta tags to the header.