### PR TITLE
fixing "status" pagination in admin post listing

### DIFF
--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -64,7 +64,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
         $perpage = Config::get('admin.posts_per_page');
         $total = $query->count();
         $posts = $query->sort('title')->take($perpage)->skip(($post - 1) * $perpage)->get();
-        $url = Uri::to('admin/posts/status');
+        $url = Uri::to('admin/posts/status/' . $status);
 
         $pagination = new Paginator($posts, $total, $post, $perpage, $url);
 


### PR DESCRIPTION
### Fix

When viewing posts with a particular status, the pagination wasn't working. The actual "status" part of the URL was being dropped. This fixes that.

### Changes proposed:

For example:

 - You're looking drafts, at: *admin/posts/status/draft*
 - You click on page two in the pagination bar at the bottom.
 - The link goes to: *admin/posts/status/2*
 - It should have gone to: *admin/posts/status/draft/2*

This fix just adds the "status" text back into the URL.