### PR TITLE
Updated .gitignore to ignore unsafe directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ vendor/
 
 # Don't want to commit .lock files
 *.lock
+
+# Ignore extension files that get placed in the .vscode folder (these files can contain credentials)
+/.vscode/*


### PR DESCRIPTION
### Fix/Feature for #1148

This Pull adds the .vscode folder (which is an unnecessary part of the Anchor CMS installation anyway) to the .gitignore file, since many extensions that can be used in Visual Studio Code generate files that may contain network credentials. These files are placed inside the .vscode folder.

### Changes proposed:

- Ignore .vscode folder

