### PR TITLE
Proposed fix for #1045

### DIFF
--- a/system/start.php
+++ b/system/start.php
@@ -33,7 +33,7 @@ Input::detect(Request::method());
 /**
  * Load session config
  */
-Session::setOptions(Config::get('session'));
+Session::setOptions(Config::get('session', array()));
 
 /**
  * Read session data


### PR DESCRIPTION
### Fix for #1045

Ran into an issue that's quite comparable to #1045. Basically it boils down to a missing anchor/config/session.php file which makes the Config::get('session') call return it's default value (null) after which the Session::setOptions() call fails because it requires an array as first argument.
There is still a failure-path hidden in here (if the session.php file exists but returns anything but an array) but I think that scenario is even less likely to happen then the one from #1045
### Changes proposed:

Adding the default return value to the Config::get() call will 'fix' this
