### PR TITLE
Feature: Toggle Custom Field Type

### DIFF
--- a/anchor/migrations/220_alter_meta_field
+++ b/anchor/migrations/220_alter_meta_field
@@ -1,0 +1,16 @@
+<?php
+
+class Migration_alter_meta_field extends Migration
+{
+    public function up()
+    {
+        $table = Base::table('extend');
+        if ($this->has_table($table)) {
+            $sql = "ALTER TABLE `" . $table . "` CHANGE `field` `field` enum('text','html','image','file','toggle') NOT NULL AFTER `type`";
+            DB::ask($sql);
+        }
+    }
+    public function down()
+    {
+    }
+}

--- a/anchor/migrations/220_alter_meta_field
+++ b/anchor/migrations/220_alter_meta_field
@@ -12,5 +12,10 @@ class Migration_alter_meta_field extends Migration
     }
     public function down()
     {
+        $table = Base::table('extend');
+        if ($this->has_table($table)) {
+            $sql = "ALTER TABLE `" . $table . "` CHANGE `field` `field` enum('text','html','image','file') NOT NULL AFTER `type`";
+            DB::ask($sql);
+        }
     }
 }

--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -16,7 +16,8 @@ class extend extends Base
         'text' => 'text',
         'html' => 'html',
         'image' => 'image',
-        'file' => 'file'
+        'file' => 'file',
+        'toggle' => 'toggle'
     );
 
     public static function field($type, $key, $id = -1)
@@ -52,6 +53,12 @@ class extend extends Base
                     $md = new Markdown;
 
                     $value = $md->transform($extend->value->html);
+                }
+                break;
+
+            case 'toggle':
+                if (! empty($extend->value->toggle)) {
+                    $value = $extend->value->toggle;
                 }
                 break;
 
@@ -97,6 +104,11 @@ class extend extends Base
             case 'html':
                 $value = isset($item->value->html) ? $item->value->html : '';
                 $html = '<textarea id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="text">' . $value . '</textarea>';
+                break;
+
+            case 'toggle':
+                $value = isset($item->value->toggle) ? $item->value->toggle : 0;
+                $html = Form::checkbox('extend[' . $item->key . ']', 1, $value, array('id' => 'extend_' . $item->key));
                 break;
 
             case 'image':
@@ -242,6 +254,13 @@ class extend extends Base
         $html = Input::get('extend.' . $extend->key);
 
         return Json::encode(compact('html'));
+    }
+
+    public static function process_toggle($extend)
+    {
+        $toggle = Input::get('extend.' . $extend->key);
+
+        return Json::encode(array('toggle' => (int)$toggle));
     }
 
     /*

--- a/install/storage/anchor.sql
+++ b/install/storage/anchor.sql
@@ -22,7 +22,7 @@ CREATE TABLE `{{prefix}}comments` (
 CREATE TABLE `{{prefix}}extend` (
   `id` int(6) NOT NULL AUTO_INCREMENT,
   `type` enum('post','page','user') NOT NULL,
-  `field` enum('text','html','image','file') NOT NULL,
+  `field` enum('text','html','image','file','toggle') NOT NULL,
   `key` varchar(160) NOT NULL,
   `label` varchar(160) NOT NULL,
   `attributes` text NOT NULL,


### PR DESCRIPTION
This PR adds a much needed boolean custom field type (called a "toggle"), addressing #615. (More discussion on #703.)

Given that the `field()` function defines:

    $field->value = Json::decode($meta ? $meta->data : '{}');

It made the most sense to follow convention and store the toggle value as JSON in the following format (`anchor_page_meta`):

    +----+------+--------+--------------+
    | id | page | extend | data         |
    +----+------+--------+--------------+
    | 17 |    2 |      4 | {"toggle":1} |
    +----+------+--------+--------------+

The straightforward implementation yields a custom checkbox which themes can, of course, take advantage of to render content on the page differently depending on the state of the toggle:

    <?php if(page_custom_field('toggle')) :?>
        <p>Toggle is on</p>
    <?php else: ?>
        <p>Toggle is off</p>
    <?php endif; ?>

I think I've covered all bases here and am open to feedback. I'd like to know if I need to write any migrations script (in `anchor/migrations/`), and if so, how that would work. Thanks for reviewing!