### PR TITLE
Bugfix: Add hidden input to preserve existing images and files on custom fields

### DIFF
--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -105,7 +105,7 @@ class extend extends Base
 
 		$html = '<span class="current-file">';
 
-		if($value) {
+		if ($value) {
 			$html .= '<a href="' . asset('content/' . $value) . '" target="_blank">' . $value . '</a>';
 		}
 
@@ -113,13 +113,13 @@ class extend extends Base
 			<span class="file">
 			<input id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="file">';
 
-		if($value) {
+		if ($value) {
 			$html .= '<input type="hidden" name="extend[' . $item->key . ']" value="' . asset('content/' . $value) . '">';
 		}	
 
 		$html .= '</span>';
 
-		if($value) {
+		if ($value) {
 			$html .= '</p><p>
 			<label>' . __('global.delete') . ' ' . $item->label . ':</label>
 			<input type="checkbox" name="extend_remove[' . $item->key . ']" value="1">';


### PR DESCRIPTION
Adds hidden input necessary to preserve existing values of custom field images and files when saving. Currently they are overwritten with no value on save because the value is not rendered in the form.

### Changes proposed:

-Add a hidden field with name and value of existing asset so that they are preserved on save.