### PR TITLE
Fix issue #1150

### DIFF
--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -112,6 +112,7 @@ class extend extends Base
                 $html .= '</span>
 					<span class="file">
 					<input id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="file">
+					<input type="hidden" name="extend[' . $item->key . ']" value="' . asset('content/' . $value) . '">
 					</span>';
 
                 if ($value) {


### PR DESCRIPTION
### Fix/Feature for #1150 

Added a missing line in order to fully populate image and file type extend fields in the post editor. Saved images and files are no longer wiped out by editing a post as described in #1150.

### Changes proposed:

- Added line to `Extend::html()`
