### PR TITLE
empty() requires pass by reference.  This achieves the same result wi…

### DIFF
--- a/install/libraries/installer.php
+++ b/install/libraries/installer.php
@@ -19,7 +19,7 @@ class installer
         static::connect($settings);
 
         // check we have not already installed
-        if (empty(static::$connection->instance()->query('SHOW DATABASES LIKE ' . static::$connection->instance()->quote($settings['database']['name']) . ';')->fetchColumn())) {
+        if (!static::$connection->instance()->query('SHOW DATABASES LIKE ' . static::$connection->instance()->quote($settings['database']['name']) . ';')->fetchColumn()) {
             
          // create the database and use the database
          static::$connection->instance()->query('CREATE DATABASE ' . substr(static::$connection->instance()->quote($settings['database']['name']),1,-1) . ';');


### PR DESCRIPTION
…th a direct value.  Addresses issue #1172 https://github.com/anchorcms/anchor-cms/issues/1172

### Fix/Feature for #0000

Fixes PHP error during installation by removing pass-by-value in pass-by-reference context.

### Changes proposed:

- A list of changes you've made
