### PR TITLE
PHP7 compatibility

### DIFF
--- a/anchor/config/aliases.php
+++ b/anchor/config/aliases.php
@@ -6,7 +6,7 @@ return array(
     'Config' => 'System\\Config',
     'Cookie' => 'System\\Cookie',
     'DB' => 'System\\Database',
-    'Error' => 'System\\Error',
+    'Errors' => 'System\\Error',
     'Input' => 'System\\Input',
     'Query' => 'System\\Database\\Query',
     'Record' => 'System\\Database\\Record',

--- a/anchor/run.php
+++ b/anchor/run.php
@@ -43,10 +43,10 @@ try {
     if (ini_get('display_errors') != "1") {
         echo "<h1>Something went wrong, please notify the owner of the site</h1>";
     } else {
-        Error::exception($e);
+        Errors::exception($e);
     }
 
-    Error::log($e);
+    Errors::log($e);
     die();
 }
 

--- a/index.php
+++ b/index.php
@@ -22,11 +22,11 @@
 */
 
 define('DS', DIRECTORY_SEPARATOR);
-define('ENV', getenv('APP_ENV'));
+define('ENV', getenv('APP_ENV') || 'dev');
 define('VERSION', '0.12.1');
 define('MIGRATION_NUMBER', 213);
 
-define('PATH', dirname(__FILE__) . DS);
+define('PATH', __DIR__ . DS);
 define('APP', PATH . 'anchor' . DS);
 define('SYS', PATH . 'system' . DS);
 define('EXT', '.php');

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@
 */
 
 define('DS', DIRECTORY_SEPARATOR);
-define('ENV', getenv('APP_ENV') || 'dev');
+define('ENV', getenv('APP_ENV'));
 define('VERSION', '0.12.1');
 define('MIGRATION_NUMBER', 213);
 

--- a/install/config/aliases.php
+++ b/install/config/aliases.php
@@ -6,7 +6,7 @@ return array(
     'Config' => 'System\\Config',
     'Cookie' => 'System\\Cookie',
     'DB' => 'System\\Database',
-    'Error' => 'System\\Error',
+    'Errors' => 'System\\Error',
     'Input' => 'System\\Input',
     'Query' => 'System\\Database\\Query',
     'Record' => 'System\\Database\\Record',

--- a/install/index.php
+++ b/install/index.php
@@ -25,7 +25,7 @@ define('DS', DIRECTORY_SEPARATOR);
 define('ENV', getenv('APP_ENV'));
 define('VERSION', '0.12.1');
 
-define('PATH', dirname(dirname(__FILE__)) . DS);
+define('PATH', dirname(__DIR__) . DS);
 define('APP', PATH . 'install' . DS);
 define('SYS', PATH . 'system' . DS);
 define('EXT', '.php');


### PR DESCRIPTION
### (partial) Fix for #1180

Saw ticket #1180, did some checking, only failure was the Error alias (since PHP7 has it's own), fixed that.
Didn't look at the mcrypt stuff, will do at a later date probably.

### Changes proposed:

- Renamed the Error alias to Errors
- Replaced dirname call with __DIR__
