### PR TITLE
Fix issue #1186

### DIFF
--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -9,7 +9,8 @@ function __($line)
 
 function is_admin()
 {
-    return strpos(Uri::current(), 'admin') === 0;
+    // Exact URI or trailing slash after 'admin'.
+	return Uri::current() === 'admin' || strpos(Uri::current(), 'admin/') === 0;
 }
 
 function is_installed()


### PR DESCRIPTION
Access to site page starting with `admin` slug was impossible.

### Fix/Feature for #1186

This fixes the issue #1186, which made access to site page which slug started with `admin` was impossible.

### Changes proposed:

- The `is_admin` helper was modified to allow access to pages with slug starting with `admin`.