### PR TITLE
Self-Upgrading Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ vendor/
 
 # Don't want to commit .lock files
 *.lock
+
+# Don't commit the updater files
+/anchor_update/
+/anchor_update/*

--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -9,7 +9,8 @@ function __($line)
 
 function is_admin()
 {
-    return strpos(Uri::current(), 'admin') === 0;
+    // Exact URI or trailing slash after 'admin'.
+	return Uri::current() === 'admin' || strpos(Uri::current(), 'admin/') === 0;
 }
 
 function is_installed()
@@ -47,8 +48,6 @@ function parse($str, $markdown = true)
         $str = str_replace($search, $replace, $str);
     }
 
-    $str = html_entity_decode($str, ENT_NOQUOTES, System\Config::app('encoding'));
-
     //  Parse Markdown as well?
     if ($markdown === true) {
         $md = new Parsedown;
@@ -63,4 +62,21 @@ function readable_size($size)
     $unit = array('b','kb','mb','gb','tb','pb');
 
     return round($size / pow(1024, ($i = floor(log($size, 1024)))), 2) . ' ' . $unit[$i];
+}
+
+function recurse_copy($src,$dst)
+{
+    $dir = opendir($src);
+    @mkdir($dst);
+    while(false !== ( $file = readdir($dir)) ) {
+        if (( $file != '.' ) && ( $file != '..' )) {
+            if ( is_dir($src . '/' . $file) ) {
+                recurse_copy($src . '/' . $file,$dst . '/' . $file);
+            }
+            else {
+                copy($src . '/' . $file,$dst . '/' . $file);
+            }
+        }
+    }
+    closedir($dir);
 }

--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -68,19 +68,18 @@ function recurse_copy($src,$dst)
 {
     $dir = opendir($src);
     @mkdir($dst);
-    while(false !== ( $file = readdir($dir)) ) {
-        if (( $file != '.' ) && ( $file != '..' )) {
-            if ( is_dir($src . '/' . $file) ) {
-                recurse_copy($src . '/' . $file,$dst . '/' . $file);
-            }
-            else {
-                copy($src . '/' . $file,$dst . '/' . $file);
+    while(false !== ($file = readdir($dir))) {
+        if(($file != '.') && ($file != '..')) {
+            if(is_dir($src . DS . $file)) {
+                recurse_copy($src . DS . $file, $dst . DS . $file);
+            } else {
+                copy($src . DS . $file, $dst . DS . $file);
             }
         }
     }
     closedir($dir);
 }
-public static function delTree($dir)
+function delTree($dir)
 {
     $files = array_diff(scandir($dir), array('.','..'));
     foreach($files as $file) {

--- a/anchor/helpers.php
+++ b/anchor/helpers.php
@@ -80,3 +80,11 @@ function recurse_copy($src,$dst)
     }
     closedir($dir);
 }
+public static function delTree($dir)
+{
+    $files = array_diff(scandir($dir), array('.','..'));
+    foreach($files as $file) {
+      (is_dir("$dir/$file")) ? delTree("$dir/$file") : unlink("$dir/$file");
+    }
+    return rmdir($dir);
+}

--- a/anchor/language/en_GB/global.php
+++ b/anchor/language/en_GB/global.php
@@ -26,6 +26,7 @@ return array(
     'reset' => 'Reset',
     'all' => 'All',
     'cancel' => 'Cancel',
+    'error' => 'Error',
 
     // pagination
     'next' => 'Next',
@@ -48,7 +49,7 @@ return array(
     'administrator' => 'Admin',
     'editor' => 'Editor',
     'user' => 'User',
-
+    
     'log_in' => 'Log in',
     'login' => 'Login',
     'log_out' => 'Log out',
@@ -58,6 +59,8 @@ return array(
     'visit_your_site' => 'Visit your site',
     'powered_by_anchor' => 'Powered by Anchor, version %s',
     'make_blogging_beautiful' => 'Make blogging beautiful',
+    'error_phrase' => 'Oh no! Your Anchor has gotten caught on something...',
+    'error_button' => 'Get me out of here!',
 
     // intro
     'welcome_to_anchor' => 'Welcome to Anchor',
@@ -66,10 +69,16 @@ return array(
 
     // upgrade
     'upgrade' => 'Upgrade',
+    'upgrading' => 'Upgrading...',
     'good_news' => 'Great News!',
     'new_version_available' => 'There\'s a new version of anchor available.',
+    'up_to_date' => 'You\'re up to date. Your Anchor is showing no signs of rust!',
+    'better_version' => 'You must\'ve snapped up a futuristic Anchor! The newest version is below your version number.',
     'download_now' => 'Download Now',
     'upgrade_later' => 'Upgrade Later',
+    'upgrade_good' => 'Anchor successfully upgraded!',
+    'upgrade_bad' => 'Anchor couldn\'t quite get to the latest version...',
+    'upgrade_finished_thanks' => 'Sweet, thanks!',
 
     // debug profiler
     'profile' => 'Profile',

--- a/anchor/libraries/update.php
+++ b/anchor/libraries/update.php
@@ -7,10 +7,7 @@ class update
         if (! $last = Config::meta('last_update_check')) {
             $last = static::setup();
         }
-        // was update in the last 30 days
-        if (strtotime($last) < time() - (60 * 60 * 24 * 30)) {
-            static::renew();
-        }
+        static::renew();
     }
     public static function setup()
     {

--- a/anchor/libraries/update.php
+++ b/anchor/libraries/update.php
@@ -64,12 +64,35 @@ class update
     {
         $result = false;
         
+        $output_folder = PATH . "anchor_update" . DS;
+        $output_file = $output_folder . "anchor_$version.zip";
+        @mkdir(dirname($output_file));
+        
+        if(false && in_array(ini_get('allow_url_fopen'), array('true', '1', 'On'))) {
+            try {
+                copy($url, $output_file);
+            } catch(Excpetion $e) {
+                // Error::log("Unable to update... Exception:\n$e");
+            }
+        } else {
+            try {
+                $session = curl_init();
+                curl_setopt_array($session, array(
+                    CURLOPT_URL => $url,
+                    CURLOPT_HEADER => false,
+                    CURLOPT_RETURNTRANSFER => true
+                ));
+                $d = curl_exec($session);
+                curl_close($session);
+                $f = fopen($output_file, 'w+');
+                fputs($f, $d);
+                fclose($f);
+            } catch(Excpetion $e) {
+                // Error::log("Unable to update... Exception:\n$e");
+            }
+        }
+        
         try {
-            $output_folder = PATH . "anchor_update" . DS;
-            $output_file = $output_folder . "anchor_$version.zip";
-            @mkdir(dirname($output_file));
-            copy($url, $output_file);
-            
             $zip = new ZipArchive;
             if($zip->open($output_file) === true) {
                 $zip->extractTo($output_folder);
@@ -84,7 +107,7 @@ class update
 
             delTree($output_folder);
         } catch(Exception $e) {
-            Error::log("Unable to update... Exception:\n$e");
+            // Error::log("Unable to update... Exception:\n$e");
         }
         
         return $result;

--- a/anchor/libraries/update.php
+++ b/anchor/libraries/update.php
@@ -84,6 +84,8 @@ class update
                 copy($output_folder . "index.php", PATH . "index.php");
                 $result = true;
             } else throw new Exception("Cannot open the downloaded archive - you may need to extract the contents manually! See https://anchorcms.com/docs/getting-started/upgrading.");
+
+            delTree($output_folder);
         } catch(Exception $e) {
             Error::log("Unable to update... Exception:\n$e");
         }

--- a/anchor/libraries/update.php
+++ b/anchor/libraries/update.php
@@ -104,9 +104,10 @@ class update
         }
         
         try {
-            $result .= '|-|Attempting to open zip file.';
+            $result .= '|-|Testing if ZipArchive is a valid PHP class.';
             $zip = new ZipArchive;
-            if($zip->open($output_file) === true) {
+            $result .= '|-|Attempting to open zip file.';
+            if(($zipCode = $zip->open($output_file)) === true) {
                 $result .= '|-|Extracting zip file.';
                 $zip->extractTo($output_folder);
                 $output_folder .= $zip->getNameIndex(0);
@@ -119,7 +120,7 @@ class update
                 copy($output_folder . "index.php", PATH . "index.php");
                 $result .= '|-|Recursive copy complete.';
                 $result = substr_replace($result, 'true', 0, strlen('false'));
-            } else throw new Exception("Cannot open the downloaded archive - you may need to extract the contents manually! See https://anchorcms.com/docs/getting-started/upgrading.");
+            } else throw new Exception("Cannot open the downloaded archive (CODE: $zipCode) - you may need to extract the contents manually! See https://anchorcms.com/docs/getting-started/upgrading.");
             
             $result .= '|-|Deleting temporary upgrade files.';
             delTree($output_folder);

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -215,12 +215,15 @@ Route::post('admin/upgrade', array('before' => 'auth', 'main' => function() {
 	
 	$version = Config::meta('update_version');
 	$url = 'https://github.com/anchorcms/anchor-cms/archive/%s.zip';
-    $success = Update::upgrade(sprintf($url, $version), $version);
     
-    sleep(5);
+    $success = Update::upgrade(sprintf($url, $version), $version);
+    $error = substr($success, -strlen('error')) == "ERROR";
+    $messages = explode('|-|', $success);
     
     return Response::json(array(
-        'success' => $success
+        'success'  => substr($success, 0, strpos($success, '|-|')) == 'true',
+        'error'    => $error,
+        'messages' => $messages
     ));
 }));
 

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -215,7 +215,7 @@ Route::post('admin/upgrade', array('before' => 'auth', 'main' => function() {
 	
 	$version = Config::meta('update_version');
 	$url = 'https://github.com/anchorcms/anchor-cms/archive/%s.zip';
-    $success = false; //Update::upgrade(sprintf($url, $version), $version);
+    $success = Update::upgrade(sprintf($url, $version), $version);
     
     sleep(5);
     

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -198,23 +198,31 @@ Route::post('admin/reset/(:any)', array('before' => 'csrf', 'main' => function (
 /*
     Upgrade
 */
-Route::get('admin/upgrade', function () {
+Route::get('admin/upgrade', array('before' => 'auth', 'main' => function () {
     $vars['token'] = Csrf::token();
 
     $version = Config::meta('update_version');
-    $url = 'https://github.com/anchorcms/anchor-cms/archive/%s.zip';
-
-    $vars['version'] = $version;
-    $vars['url'] = sprintf($url, $version);
     
-    // Update programmatically
+    $vars['version'] = Update::touch();
     
-    $vars['auto_upgrade'] = Update::upgrade(sprintf($url, $version), $version);
-
     return View::create('upgrade', $vars)
         ->partial('header', 'partials/header')
         ->partial('footer', 'partials/footer');
-});
+}));
+
+Route::post('admin/upgrade', array('before' => 'auth', 'main' => function() {
+	// Update programmatically
+	
+	$version = Config::meta('update_version');
+	$url = 'https://github.com/anchorcms/anchor-cms/archive/%s.zip';
+    $success = false; //Update::upgrade(sprintf($url, $version), $version);
+    
+    sleep(5);
+    
+    return Response::json(array(
+        'success' => $success
+    ));
+}));
 
 /*
     List extend

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -198,7 +198,6 @@ Route::post('admin/reset/(:any)', array('before' => 'csrf', 'main' => function (
     Upgrade
 */
 Route::get('admin/upgrade', function () {
-    
     $vars['token'] = Csrf::token();
 
     $version = Config::meta('update_version');
@@ -206,6 +205,10 @@ Route::get('admin/upgrade', function () {
 
     $vars['version'] = $version;
     $vars['url'] = sprintf($url, $version);
+    
+    // Update programmatically
+    
+    $vars['auto_upgrade'] = Update::upgrade(sprintf($url, $version), $version);
 
     return View::create('upgrade', $vars)
         ->partial('header', 'partials/header')

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -55,6 +55,7 @@ Route::get('admin/login', array('before' => 'guest', 'main' => function () {
     }
     
     $vars['token'] = Csrf::token();
+    if(!array_key_exists('messages', $vars)) $vars['messages'] = "";
 
     return View::create('users/login', $vars)
         ->partial('header', 'partials/header')

--- a/anchor/routes/admin.php
+++ b/anchor/routes/admin.php
@@ -214,7 +214,7 @@ Route::post('admin/upgrade', array('before' => 'auth', 'main' => function() {
 	// Update programmatically
 	
 	$version = Config::meta('update_version');
-	$url = 'https://github.com/anchorcms/anchor-cms/archive/%s.zip';
+	$url = 'https://codeload.github.com/anchorcms/anchor-cms/zip/%s';
     
     $success = Update::upgrade(sprintf($url, $version), $version);
     $error = substr($success, -strlen('error')) == "ERROR";

--- a/anchor/views/upgrade.php
+++ b/anchor/views/upgrade.php
@@ -45,9 +45,16 @@
 
 			<h1><?php echo __('global.good_news'); ?></h1>
 			<p><?php echo __('global.new_version_available'); ?></p>
-
-			<a href="<?php echo $url; ?>"><?php echo __('global.download_now'); ?></a>
-			<a href="<?php echo $base; ?>/admin"><?php echo __('global.upgrade_later'); ?></a>
+			<p><small style="color:grey;"><?php echo VERSION; ?></small><span> > <?php echo $version; ?></span></p>
+			<?php
+				if($auto_upgrade) {
+					echo '<br><p>Even better news! Anchor upgraded itself like a dancing robot!</p><img src="https://i.imgur.com/VKKeQX6.gif" width=350>';
+				} else {
+					echo "<p>Oh oh! Seems like Anchor missed the dock while trying to upgrade. Look's like it's gotta be done manually!</p>";
+					echo '<a href="' . $url . '">' . __('global.download_now') . '</a>';
+					echo '<a href="' . $base . '/admin">' . __('global.upgrade_later') . '</a>';
+				}
+			?>
 		</div>
 	</body>
 </html>

--- a/anchor/views/upgrade.php
+++ b/anchor/views/upgrade.php
@@ -57,6 +57,10 @@
 				transform-origin: 50% 18.2%;
     			animation: spinning 1s infinite linear;
 			}
+			.dancing_robot {
+				width: 100% !important;
+				margin-top: 30px;
+			}
 			@keyframes spinning {
 			  0%   { transform: rotate(0deg); }
 			  100% { transform: rotate(360deg); }
@@ -95,9 +99,9 @@
 		<div id="finished" hidden>
 			<img src="<?php echo $base; ?>/anchor/views/assets/img/logo.png" alt="Anchor logo">
 			<h1 class="fin_h1"></h1>
-			<img class="dancing_robot" src="https://i.imgur.com/VKKeQX6.gif" alt="Gangnam Robot!" />
 			<a class="fin_goBack" href="<?php echo Uri::to('admin/upgrade/'); ?>">Try again</a>
 			<a class="fin_continue" href="<?php echo Uri::to('admin/'); ?>">Nevermind</a>
+			<img class="dancing_robot" src="https://i.imgur.com/VKKeQX6.gif" alt="Gangnam Robot!" />
 		</div>
 		<script type="text/javascript" src="<?php echo $base; ?>/anchor/views/assets/js/zepto.js"></script>
 		<script>

--- a/anchor/views/upgrade.php
+++ b/anchor/views/upgrade.php
@@ -95,6 +95,7 @@
 		<div id="finished" hidden>
 			<img src="<?php echo $base; ?>/anchor/views/assets/img/logo.png" alt="Anchor logo">
 			<h1 class="fin_h1"></h1>
+			<img class="dancing_robot" src="https://i.imgur.com/VKKeQX6.gif" alt="Gangnam Robot!" />
 			<a class="fin_goBack" href="<?php echo Uri::to('admin/upgrade/'); ?>">Try again</a>
 			<a class="fin_continue" href="<?php echo Uri::to('admin/'); ?>">Nevermind</a>
 		</div>
@@ -118,6 +119,9 @@
 					if(success) {
 						goBack.parentNode.removeChild(goBack);
 						cont.innerText = "<?php echo __('global.upgrade_finished_thanks')?>";
+					} else {
+						var robot = document.querySelector(".dancing_robot");
+						robot.parentNode.removeChild(robot);
 					}
 					
 					!success && addClass(document.querySelector("body"), "error");

--- a/anchor/views/upgrade.php
+++ b/anchor/views/upgrade.php
@@ -12,13 +12,23 @@
 				background: #444f5f;
 				color: #fff;
 			}
+			body.finished {
+				background: #89b92c;
+    			color: #2f3744;	
+			}
+			body.finished.error {
+				background: #dd403c;
+			}
 			div {
 				width: 400px;
-				height: 160px;
 				position: absolute;
 				left: 50%;
 				top: 30%;
 				margin: -80px 0 0 -200px;
+				padding: 30px;
+				box-sizing: border-box;
+			    border-radius: 5px;
+			    background-color: rgba(255,255,255,0.3);
 			}
 			h1 {
 				font-size: 29px;
@@ -26,7 +36,7 @@
 				font-weight: 300;
 				margin: 30px 0;
 			}
-			a {
+			a, .btn {
 				display: inline-block;
 				padding: 0 22px;
 				background: #2F3744;
@@ -36,25 +46,115 @@
 				font-weight: bold;
 				text-decoration: none;
 				border-radius: 5px;
+				margin-left: 5px;
+				margin-right: 5px;
+				border: none;
+				cursor: pointer;
+			}
+			p > small {
+				color: rgba(0,0,0,0.4);
+			}
+			.loadAnchor {
+				transform-origin: 50% 18.2%;
+    			animation: spinning 1s infinite linear;
+			}
+			@keyframes spinning {
+			  0%   { transform: rotate(0deg); }
+			  100% { transform: rotate(360deg); }
 			}
 		</style>
 	</head>
 	<body>
-		<div>
+		<div id="start">
 			<img src="<?php echo $base; ?>/anchor/views/assets/img/logo.png" alt="Anchor logo">
-
-			<h1><?php echo __('global.good_news'); ?></h1>
-			<p><?php echo __('global.new_version_available'); ?></p>
-			<p><small style="color:grey;"><?php echo VERSION; ?></small><span> > <?php echo $version; ?></span></p>
-			<?php
-				if($auto_upgrade) {
-					echo '<br><p>Even better news! Anchor upgraded itself like a dancing robot!</p><img src="https://i.imgur.com/VKKeQX6.gif" width=350>';
-				} else {
-					echo "<p>Oh oh! Seems like Anchor missed the dock while trying to upgrade. Look's like it's gotta be done manually!</p>";
-					echo '<a href="' . $url . '">' . __('global.download_now') . '</a>';
-					echo '<a href="' . $base . '/admin">' . __('global.upgrade_later') . '</a>';
-				}
-			?>
+			<?php $compare = version_compare(VERSION, $version); ?>
+			<?php if($compare < 0) : // new release available ?>
+				<h1><?php echo __('global.good_news'); ?></h1>
+				<p><?php echo __('global.new_version_available'); ?></p>
+				<p><small><?php echo VERSION; ?></small><span> &rarr; <?php echo $version; ?></span></p>
+            	<a href="#" onclick="sendAjax()"><?php echo __('global.download_now'); ?></a>
+				<a href="<?php echo $base; ?>/admin"><?php echo __('global.upgrade_later'); ?></a>
+			<?php elseif($compare == 0) : // same version as newest ?>
+				<h1><?php echo __('global.good_news'); ?></h1>
+				<p><?php echo __('global.up_to_date'); ?></p>
+				<p><?php echo VERSION; ?></p>
+				<a href="<?php echo $base; ?>/admin"><?php echo __('global.upgrade_finished_thanks'); ?></a>
+			<?php elseif($compare > 0) : // we're at least one ahead! ?>
+				<h1>Ooooooweeeeee!</h1>
+				<p><?php echo __('global.better_version'); ?></p>
+				<p><span><?php echo VERSION; ?> &#10567; </span><small><?php echo $version; ?></small></p>
+				<a href="<?php echo $base; ?>/admin"><?php echo __('global.upgrade_finished_thanks'); ?></a>
+			<?php else : // SOMETHING'S WRONG! ?>
+				<p><?php __('global.error_phrase'); ?></p>
+				<a href="<?php echo $base; ?>/admin"><?php echo __('global.error_button'); ?></a>
+			<?php endif; ?>
 		</div>
+		<div id="loading" hidden>
+			<img class="loadAnchor" src="<?php echo $base; ?>/anchor/views/assets/img/logo.png" alt="Anchor logo">
+			<h1><?php echo __('global.updating'); ?></h1>
+		</div>
+		<div id="finished" hidden>
+			<img src="<?php echo $base; ?>/anchor/views/assets/img/logo.png" alt="Anchor logo">
+			<h1 class="fin_h1"></h1>
+			<a class="fin_goBack" href="<?php echo Uri::to('admin/upgrade/'); ?>">Try again</a>
+			<a class="fin_continue" href="<?php echo Uri::to('admin/'); ?>">Nevermind</a>
+		</div>
+		<script type="text/javascript" src="<?php echo $base; ?>/anchor/views/assets/js/zepto.js"></script>
+		<script>
+			var sendAjax;
+			(function($) {
+				function addClass(el, clazz) {
+					if(!el) return;
+					if(el.classList) el.classList.add(clazz);
+					else el.className += " " + clazz;
+				}
+				
+				function finished(success) {
+					var h1 = success ? "<?php echo __('global.upgrade_good'); ?>" : "<?php echo __('global.upgrade_bad'); ?>";
+					document.querySelector(".fin_h1").innerText = h1;
+					
+					var goBack = document.querySelector(".fin_goBack");
+					var cont = document.querySelector(".fin_continue");
+					
+					if(success) {
+						goBack.parentNode.removeChild(goBack);
+						cont.innerText = "<?php echo __('global.upgrade_finished_thanks')?>";
+					}
+					
+					!success && addClass(document.querySelector("body"), "error");
+					setActiveDiv("finished");
+				}
+				
+				function setActiveDiv(div) {
+					document.querySelector("#start").hidden = true;
+					document.querySelector("#loading").hidden = true;
+					document.querySelector("#finished").hidden = true;
+					document.querySelector("#" + div).hidden = false;
+					
+					if(div === "finished") {
+						addClass(document.querySelector("body"), "finished")
+					}
+				}
+				
+				sendAjax = function() {
+					$.ajax({
+						url: "<?php echo Uri::to('admin/upgrade/'); ?>",
+						type: "POST",
+						success: function(data, textStatus, jqXHR) {
+							data = JSON.parse(data);
+							console.log(data);
+							finished(!!data.success);
+						},
+						error: function(jqXHR, textStatus, errorThrown) {
+							// Error executing ajax.
+							console.log(errorThrown);
+							finished(false);
+						}
+					});
+					
+					setActiveDiv("loading");
+				}
+			}(Zepto));
+		</script>
 	</body>
 </html>

--- a/anchor/views/upgrade.php
+++ b/anchor/views/upgrade.php
@@ -4,7 +4,6 @@
 	<head>
 		<meta charset="utf-8">
 		<title><?php echo __('global.upgrade'); ?></title>
-
 		<style>
 			body {
 				font: 100% "Helvetica Neue", "Open Sans", "DejaVu Sans", "Arial", sans-serif;
@@ -153,7 +152,7 @@
 					});
 					
 					setActiveDiv("loading");
-				}
+				};
 			}(Zepto));
 		</script>
 	</body>

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
 
 define('DS', DIRECTORY_SEPARATOR);
 define('ENV', getenv('APP_ENV'));
-define('VERSION', '0.12.1');
+define('VERSION', '0.12.3');
 define('MIGRATION_NUMBER', 220);
 
 define('PATH', __DIR__ . DS);


### PR DESCRIPTION
### Feature to auto-upgrade the core of AnchorCMS

This feature aims to simplify the process that a user must follow to upgrade AnchorCMS. Now it is no longer download the archive, and FTP. All you need to do is click a button, and hope for the best!

### Changes proposed:

- Added to `.gitignore`, so git doesn't see the upgrade data. Simply just temporary files.
- Added helper methods to delete file trees and recursively copy files.
- Added a few words and phrases to the `enGB` locale - all dealing with the upgrade functionality.
- Updated the function to get the latest version number.
- Added a new function that upgrades Anchor from inside Anchor (complete with debugging messages).
- Updated the `GET` route and added a `POST` route to better reflect the procedure of upgrading.
- Updated the front-end to look more effective.

Just placing this here for QA purposes. Go ahead, give it a go!