### PR TITLE
Fixes #1208

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -219,7 +219,7 @@ Route::collection(array('before' => 'auth,csrf,install_exists'), function () {
             // Notify::error($errors);
 
             return Response::json(array(
-                'id'     => $id,
+                'id'     => $page->id,
                 'errors' => array_flatten($errors, array())
             ));
         }


### PR DESCRIPTION
Missed page ID on add page route

### Fix for #1208 


### Changes proposed:
- Changed `$id` to `$page->id` on add page route (L222)