### PR TITLE
Always show scrollbar

### DIFF
--- a/anchor/views/assets/css/admin.css
+++ b/anchor/views/assets/css/admin.css
@@ -6,6 +6,10 @@
 /*
 	Admin panel-wide styles
 */
+html {
+	overflow-y: scroll;
+}
+
 body {
 	background: #eceef1;
 	color: #7d8693;


### PR DESCRIPTION
Always show vertical scrollbar in admin panel, to prevent content shifting to the left when scrollbar becomes active.