### PR TITLE
Fix comments having HTML escaped characters

### DIFF
--- a/themes/default/article.php
+++ b/themes/default/article.php
@@ -23,7 +23,7 @@
 						<time><?php echo relative_time(comment_time()); ?></time>
 
 						<div class="content">
-							<?php echo htmlspecialchars(comment_text()); ?>
+							<?php echo comment_text(); ?>
 						</div>
 
 						<span class="counter"><?php echo $i; ?></span>


### PR DESCRIPTION
### Fix for comments being HTML escaped in the default theme
Comments are stored HTML encoded in the database, and then re-encoded before being sent to the client

### Changes proposed:
Remove the HTML encoding from the default theme for comments.