### PR TITLE
Specify CURRENT_TIMESTAMP as the default for DATETIME columns. Fix #1219

### DIFF
--- a/anchor/migrations/21_alter_comments_date.php
+++ b/anchor/migrations/21_alter_comments_date.php
@@ -8,7 +8,7 @@ class Migration_alter_comments_date extends Migration
         $table = Base::table('comments');
 
         if ($this->has_table($table)) {
-            $sql = 'ALTER TABLE `' . $table . '` CHANGE `date` `date` datetime NOT NULL AFTER `status`';
+            $sql = 'ALTER TABLE `' . $table . '` CHANGE `date` `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `status`';
             DB::ask($sql);
         }
     }

--- a/anchor/migrations/61_alter_posts_created.php
+++ b/anchor/migrations/61_alter_posts_created.php
@@ -8,7 +8,7 @@ class Migration_alter_posts_created extends Migration
         $table = Base::table('posts');
 
         if ($this->has_table_column($table, 'created')) {
-            $sql = 'ALTER TABLE `' . $table . '` CHANGE `created` `created` datetime NOT NULL AFTER `js`';
+            $sql = 'ALTER TABLE `' . $table . '` CHANGE `created` `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `js`';
             DB::ask($sql);
         }
     }


### PR DESCRIPTION
### Fix/Feature for #1219 

Specify `CURRENT_TIMESTAMP` as the default for `DATETIME` columns to avoid the `Invaild use of Null value` error.

### Changes proposed:

- add `DEFAULT CURRENT_TIMESTAMP` to the migrations SQL statements of 21_alter_comments_date.php and 61_alter_posts_created.php.