### PR TITLE
Fixed CVE-2018-7251

### DIFF
--- a/anchor/.htaccess
+++ b/anchor/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
I reported this to the MITRE corporation yesterday. The problem is not that stack traces are logged to `/anchor/errors.log`, but more that the `errors.log` file is accessible via the web with the default installation of Anchor CMS.

Normally the `errors.log` file wouldn't contain credentials. However, when you perform a denial of service on the website you have the chance that Anchor CMS will make too much concurrent connections to MySQL. This will throw a PHP error including the stack trace and arguments to `/anchor/errors.log`. The arguments contain the database credentials.

Therefore it is possible that the database credentials are accessible via the `error.log` on `http://an-anchor-blog[dot]com/anchor/errors.log`.

### Fix/Feature for CVE-2018-7251 #1247 

This fix will block all access to the Anchor directory since there's no need to access it via the web.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7251

### Changes proposed:

- I added a `.htaccess` file to the Anchor folder
