### PR TITLE
Allow access to the admin asset folder

### DIFF
--- a/anchor/.htaccess
+++ b/anchor/.htaccess
@@ -1,1 +1,0 @@
-Deny from all

--- a/anchor/views/assets/.htaccess
+++ b/anchor/views/assets/.htaccess
@@ -1,0 +1,1 @@
+Allow from all

--- a/anchor/views/assets/.htaccess
+++ b/anchor/views/assets/.htaccess
@@ -1,1 +1,0 @@
-Allow from all

--- a/install/storage/htaccess.distro
+++ b/install/storage/htaccess.distro
@@ -12,8 +12,9 @@ Options -indexes
 	RewriteRule ^(.*)$ {{index}} [L]
 
 	#Rewrite anchor directories to index.php/URL even though they exist.
-	#Don't rewrite files so that we can still load CSS, etc.
+	#Don't rewrite files so that we can still load CSS, etc (except .log files).
 	RewriteCond %{REQUEST_FILENAME} -f
+	RewriteCond %{REQUEST_URI} !\.log$
 	RewriteRule .* - [S=5]
 
 	RewriteRule ^(system(?:$|\/.*$)) {{index}} [L]


### PR DESCRIPTION
It seems like my pull request #1248 broke access to the assets folder, as reported in issue #1249. The only access needed in the `/anchor` folder is for the assets, so I added a `.htaccess` file which allows all access to the assets folder. This seems like a clean fix to me.

To be sure everything works as it should I tested it just now on my local machine.

### Fix/Feature for #1249

The `Allow from all` in the assets folder allows all access to admin assets from the web. My previous pull request blocked access to these files. Sorry for the inconvenience!

### Changes proposed:

- Added a `.htaccess` file
