### PR TITLE
Update connector.php

### DIFF
--- a/system/database/connector.php
+++ b/system/database/connector.php
@@ -73,7 +73,7 @@ abstract class connector
      */
     public static function __callStatic($method, $arguments)
     {
-        return call_user_func_array(array($this->instance(), $method), $arguments);
+        return call_user_func_array(array(self::instance(), $method), $arguments);
     }
 
     /**


### PR DESCRIPTION
A static function can not use $this.

### Fix/Feature for #0000

When you create a static function you can not use $this->.

### Changes proposed:

- Changed $this-> to static self::
