### PR TITLE
Added release automation for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,21 @@ after_script:
   - if [ -f coverage.clover ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
   # Upload code-coverage CodeClimate
   - if [ -f coverage.clover ]; then CODECLIMATE_REPO_TOKEN=<INSERT TOKEN HERE> ./vendor/bin/test-reporter --coverage-report=coverage.clover; fi
+
+# Start the release build script
+after_success: ./test/travis-ci/release.sh
+
+# Deploy to GitHub
+before_deploy: 
+  - provider: releases
+    api_key:
+      secure: "GITHUB ACCESS TOKEN"
+    file: "release.tar.gz"
+    skip_cleanup: true
+    on:
+      repo: anchorcms/anchor-cms
+      branch: master
+      tags: true
+
+after_deploy:
+# - ./deploy-gh-pages.sh

--- a/test/travis-ci/release.sh
+++ b/test/travis-ci/release.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cd $TRAVIS_BUILD_DIR
+
+# install optimized composer dependencies
+rm -rf ./vendor ./composer.lock
+composer install --no-dev --prefer-dist --optimize-autoloader --ignore-platform-reqs --no-interaction --no-suggest --no-progress
+
+# build static frontend assets
+npm run build
+
+mkdir ./release-build
+
+# copy all relevant files and directories to the build directory
+cp -R ./anchor ./content ./system ./system ./themes ./vendor ./index.php ./composer.json ./composer.lock ./readme.md ./license.md ./release-build/
+
+# create an archive from it
+tar czf ./release.tar.gz -C release-build/ *


### PR DESCRIPTION
This adds the `deploy` directive to the Travis configuration which *should* enable us to automatically build releases on tagged commits. Requires testing.  
This is up for debate, no merge immediately, please.