### PR TITLE
Fix custom field file save with empty

### DIFF
--- a/anchor/models/extend.php
+++ b/anchor/models/extend.php
@@ -150,7 +150,7 @@ class extend extends Base
                 $html .= '</span>
 					<span class="file">
 					<input id="extend_' . $item->key . '" name="extend[' . $item->key . ']" type="file">
-					<input type="hidden" name="extend[' . $item->key . ']" value="' . asset('content/' . $value) . '">
+					<input type="hidden" name="extend[' . $item->key . ']" value="' . (($value) ? asset('content/' . $value) : "") . '">
 					</span>';
 
                 if ($value) {


### PR DESCRIPTION
### Fixes files saving with empty value

Remove content path with empty image fields, only output path if the custom image field is populated.

### Changes proposed:

- Conditionally output the field value if it's set.
