### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,6 @@ after_script:
   - if [ -f coverage.clover ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
   # Upload code-coverage CodeClimate
   - if [ -f coverage.clover ]; then CODECLIMATE_REPO_TOKEN=<INSERT TOKEN HERE> ./vendor/bin/test-reporter --coverage-report=coverage.clover; fi
+
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis clones the last 50 commits. Cloning the last 5 is sufficient and faster.