### PR TITLE
Fix Migration

### DIFF
--- a/anchor/migrations/213_add_updated_fields_to_tables.php
+++ b/anchor/migrations/213_add_updated_fields_to_tables.php
@@ -9,7 +9,7 @@ class Migration_add_updated_fields_to_tables extends Migration
         if ($this->has_table($posts)) {
             if (!$this->has_table_column($posts, 'updated')) {
                 $sql  = 'ALTER TABLE `' . $posts . '` ';
-                $sql .= 'ADD COLUMN `updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created`';
+                $sql .= 'ADD COLUMN `updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created`';
                 DB::ask($sql);
             }
         }
@@ -19,7 +19,7 @@ class Migration_add_updated_fields_to_tables extends Migration
         if ($this->has_table($pages)) {
             if (!$this->has_table_column($pages, 'updated')) {
                 $sql  = 'ALTER TABLE `' . $pages . '` ';
-                $sql .= 'ADD COLUMN `updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP';
+                $sql .= 'ADD COLUMN `updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP';
                 DB::ask($sql);
             }
         }
@@ -29,7 +29,7 @@ class Migration_add_updated_fields_to_tables extends Migration
         if ($this->has_table($users)) {
             if (!$this->has_table_column($users, 'updated')) {
                 $sql  = 'ALTER TABLE `' . $users . '` ';
-                $sql .= 'ADD COLUMN `updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP';
+                $sql .= 'ADD COLUMN `updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP';
                 DB::ask($sql);
             }
         }

--- a/anchor/migrations/21_alter_comments_date.php
+++ b/anchor/migrations/21_alter_comments_date.php
@@ -8,7 +8,7 @@ class Migration_alter_comments_date extends Migration
         $table = Base::table('comments');
 
         if ($this->has_table($table)) {
-            $sql = 'ALTER TABLE `' . $table . '` CHANGE `date` `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `status`';
+            $sql = 'ALTER TABLE `' . $table . '` CHANGE `date` `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `status`';
             DB::ask($sql);
         }
     }

--- a/anchor/migrations/61_alter_posts_created.php
+++ b/anchor/migrations/61_alter_posts_created.php
@@ -8,7 +8,7 @@ class Migration_alter_posts_created extends Migration
         $table = Base::table('posts');
 
         if ($this->has_table_column($table, 'created')) {
-            $sql = 'ALTER TABLE `' . $table . '` CHANGE `created` `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `js`';
+            $sql = 'ALTER TABLE `' . $table . '` CHANGE `created` `created` DATETIME NOT NULL DEFAULT "0000-00-00 00:00:00" AFTER `js`';
             DB::ask($sql);
         }
     }


### PR DESCRIPTION
CMS attempted to update 'created' field in 'prefix_posts' to CURRENT_TIMESTAMP, then add 'updated' field with same default value - illegal move for MySQL. 'created' will now be default "0000-00-00 00:00:00", since the route for add already creates the input for 'created' as the current date/time.