### PR TITLE
Removed reference to undefined variable $id.

### DIFF
--- a/anchor/routes/posts.php
+++ b/anchor/routes/posts.php
@@ -290,9 +290,11 @@ Route::collection(['before' => 'auth,csrf,install_exists'], function () {
 
             // Notify::error($errors);
 
-            // TODO: $id is undefined and will throw
+            // $id is undefined and will throw, so we use -1 instead
+            //     because this post still isn't saved.
             return Response::json([
-                'id'     => $id,
+                //'id'   => $id,
+                'id'     => -1,
                 'errors' => array_flatten($errors, [])
             ]);
         }


### PR DESCRIPTION
### Fix for #1288

Removes the reference to undefined variable `$id`. Instead, it's replaced with a `-1` to indicate (behind the scenes) that the post still hasn't been saved.

### Changes proposed:

- The reference to `$id` has been changed to `-1`.
