### PR TITLE
fixing notificantions not displayed error

### DIFF
--- a/anchor/libraries/notify.php
+++ b/anchor/libraries/notify.php
@@ -50,7 +50,7 @@ class notify
 
         // no messages, no problem <-- Imagine this in a Borat accent
         if (is_null($types)) {
-            return '';
+            return sprintf(static::$wrap, "");
         }
 
         $html = '';


### PR DESCRIPTION
### Fix/Feature for #0000
the notifications on the javascript side were not shown because the notifications element was not created if there was no message in the session.

### Changes proposed:
- return a empty element notifications on notify::read
