### PR TITLE
Fixes #1231, You don't need an id for a page that doesn't exist yet

### DIFF
--- a/anchor/routes/pages.php
+++ b/anchor/routes/pages.php
@@ -258,9 +258,8 @@ Route::collection(['before' => 'auth,csrf,install_exists'], function () {
 
             // Notify::error($errors);
 
-            // TODO: $page is undefined. This will throw!
             return Response::json([
-                'id'     => $page->id,
+                'id'     => 0,
                 'errors' => array_flatten($errors, [])
             ]);
         }


### PR DESCRIPTION
### Fix/Feature for #1231 

My guess is originally it was planned to create a page object before saving, but it wasn't necessary. This clause only triggers when the title field is empty or doesn't meet some criteria.

### Changes proposed:

Just pass a 0 value id because it's not required to have an one on pages that don't exist yet.
