### PR TITLE
Fix composer.json 'type' to match regex pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "anchorcms/anchor-cms",
     "description": "Anchor is a free, lightweight, faster-than-a-bullet, simple blogging system, made for art–directed posts.",
-    "type": "CMS",
+    "type": "cms",
     "version": "0.12.7",
     "keywords": ["CMS", "anchor", "anchorcms"],
     "license": "GPL-3.0",


### PR DESCRIPTION
### Fix/Feature for #1330

Corrects an error in the 'type' property that does not pass Composer's validators.

### Changes proposed:

Changed uppercase `CMS` to lowercase `cms`.
