### PR TITLE
added a spacebar between Manage and the sitename

### DIFF
--- a/anchor/views/partials/header.php
+++ b/anchor/views/partials/header.php
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title><?php echo __('global.manage'); ?><?php echo Config::meta('sitename'); ?></title>
+    <title><?php echo __('global.manage'); ?> <?php echo Config::meta('sitename'); ?></title>
     <link rel="shortcut icon" type="image/png" href="<?php echo asset('anchor/views/assets/img/favicon.png'); ?>"/>
 
     <script src="<?php echo asset('anchor/views/assets/js/zepto.1.2.min.js'); ?>"></script>


### PR DESCRIPTION
### Fix

I just noticed in the admin area the Header always says: "ManageMyBlog" instead of "Manage MyBlog"

### Changes proposed:

- Just added a space on the header.php
